### PR TITLE
Add namespace property to airbyte record

### DIFF
--- a/cmd/airbyte-source/helper.go
+++ b/cmd/airbyte-source/helper.go
@@ -22,9 +22,12 @@ func (f fileReader) ReadFile(path string) ([]byte, error) {
 }
 
 func DefaultHelper() *Helper {
+	logger := internal.NewLogger()
 	return &Helper{
-		Database:   internal.PlanetScaleMySQLDatabase{},
+		Database: internal.PlanetScaleMySQLDatabase{
+			Logger: logger,
+		},
 		FileReader: fileReader{},
-		Logger:     internal.NewLogger(),
+		Logger:     logger,
 	}
 }

--- a/cmd/internal/logger.go
+++ b/cmd/internal/logger.go
@@ -11,7 +11,7 @@ type AirbyteLogger interface {
 	Log(w io.Writer, level, message string)
 	Catalog(w io.Writer, catalog Catalog)
 	ConnectionStatus(w io.Writer, status ConnectionStatus)
-	Record(w io.Writer, tableName string, data map[string]interface{})
+	Record(w io.Writer, tableNamespace, tableName string, data map[string]interface{})
 }
 
 func NewLogger() AirbyteLogger {
@@ -45,11 +45,12 @@ func (a airbyteLogger) Catalog(w io.Writer, catalog Catalog) {
 	fmt.Fprintf(w, "%s\n", msg)
 }
 
-func (a airbyteLogger) Record(w io.Writer, tableName string, data map[string]interface{}) {
+func (a airbyteLogger) Record(w io.Writer, tableNamespace, tableName string, data map[string]interface{}) {
 	now := time.Now()
 	amsg := AirbyteMessage{
 		Type: RECORD,
 		Record: &AirbyteRecord{
+			Namespace: tableNamespace,
 			Stream:    tableName,
 			Data:      data,
 			EmittedAt: now.UnixMilli(),

--- a/cmd/internal/planetscale_connection.go
+++ b/cmd/internal/planetscale_connection.go
@@ -21,10 +21,11 @@ func (psc PlanetScaleConnection) DSN() string {
 	config.Net = "tcp"
 	config.Addr = psc.Host
 	config.User = psc.Username
-	config.DBName = fmt.Sprintf("%v@replica", psc.Database)
+	config.DBName = psc.Database
 	config.Passwd = psc.Password
 	if useSecureConnection() {
 		config.TLSConfig = "true"
+		config.DBName = fmt.Sprintf("%v@replica", psc.Database)
 	}
 	return config.FormatDSN()
 }

--- a/cmd/internal/planetscale_database.go
+++ b/cmd/internal/planetscale_database.go
@@ -3,13 +3,11 @@ package internal
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"github.com/pkg/errors"
 	"io"
 	"log"
 	"strings"
-	"time"
 )
 
 type PlanetScaleDatabase interface {
@@ -19,6 +17,7 @@ type PlanetScaleDatabase interface {
 }
 
 type PlanetScaleMySQLDatabase struct {
+	Logger AirbyteLogger
 }
 
 func (p PlanetScaleMySQLDatabase) CanConnect(ctx context.Context, psc PlanetScaleConnection) (bool, error) {
@@ -149,23 +148,7 @@ func (p PlanetScaleMySQLDatabase) Read(ctx context.Context, w io.Writer, psc Pla
 			m[colName] = *val
 		}
 
-		printRecord(w, table.Name, m)
+		p.Logger.Record(w, psc.Database, table.Name, m)
 	}
-	return nil
-}
-
-func printRecord(w io.Writer, tableName string, record map[string]interface{}) error {
-	now := time.Now()
-	amsg := AirbyteMessage{
-		Type: RECORD,
-		Record: &AirbyteRecord{
-			Stream:    tableName,
-			Data:      record,
-			EmittedAt: now.UnixMilli(),
-		},
-	}
-
-	msg, _ := json.Marshal(amsg)
-	fmt.Fprintf(w, "%s\n", msg)
 	return nil
 }

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -58,6 +58,7 @@ type ConfiguredCatalog struct {
 
 type AirbyteRecord struct {
 	Stream    string                 `json:"stream"`
+	Namespace string                 `json:"namespace"`
 	EmittedAt int64                  `json:"emitted_at"`
 	Data      map[string]interface{} `json:"data"`
 }

--- a/script/e2e.sh
+++ b/script/e2e.sh
@@ -8,7 +8,7 @@ docker-compose up -d
 }
 
 importData() {
-  mysql -h 127.0.0.1 --port 3306 -uroot -pexample < ./fixture/sakila-db/sakila-schema.sql
+  mysql -h 0.0.0.0 --port 3306 -uroot -pexample < ./fixture/sakila-db/sakila-schema.sql
 }
 
 generateSource() {


### PR DESCRIPTION
This should fix the issue that @rafer reported in Slack [here](https://planetscale.slack.com/archives/C0322151DAQ/p1646690650790849)

Airbyte doesn't list all `required` properties correctly, we HAVE to send `namespace` property as part of an `AirbyteRecordMessage` object.

https://github.com/airbytehq/airbyte/blob/922bfd08a9182443599b78dbb273d70cb9f63d30/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml#L46-L66