### PR TITLE
Specify --platform linux/amd64 in build-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ COMMIT := $(shell git rev-parse --short=7 HEAD 2>/dev/null)
 VERSION := "0.1.2"
 DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 NAME := "airbyte-source"
+DOCKER_BUILD_PLATFORM := "linux/amd64"
 ifeq ($(strip $(shell git status --porcelain 2>/dev/null)),)
   GIT_TREE_STATE=clean
 else
@@ -32,7 +33,7 @@ licensed:
 .PHONY: build-image
 build-image:
 	@echo "==> Building docker image ${REPO}/${NAME}:$(VERSION)"
-	@docker build --build-arg VERSION=$(VERSION:v%=%) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) -t ${REPO}/${NAME}:$(VERSION) .
+	@docker build --platform ${DOCKER_BUILD_PLATFORM} --build-arg VERSION=$(VERSION:v%=%) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) -t ${REPO}/${NAME}:$(VERSION) .
 	@docker tag ${REPO}/${NAME}:$(VERSION) ${REPO}/${NAME}:latest
 
 .PHONY: push


### PR DESCRIPTION
Otherwise, this defaults to linux/arm64/v8 on my m1 laptop and `push` results in an image that doesn't work in most production environments.

Trying to load the `linux/arm64/v8` build on a linux GCP vm results in:

```
airbyte-worker      | 2022-03-08 18:31:14 ERROR i.a.c.i.LineGobbler(voidCall):82 - WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
airbyte-worker      | 2022-03-08 18:31:15 ERROR i.a.c.i.LineGobbler(voidCall):82 - [FATAL tini (7)] exec /usr/local/bin/connect failed: Exec format error
```

When trying to add in settings > connector.