### PR TITLE
cmd/internal: prepared query arguments, normalize queries, Go checks

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -164,10 +164,10 @@ func (p PlanetScaleEdgeDatabase) ListShards(ctx context.Context, psc PlanetScale
 	}
 	defer db.Close()
 
-	// TODO: is there a preapred statement equivalent?
+	// TODO: is there a prepared statement equivalent?
 	shardNamesQR, err := db.QueryContext(
 		ctx,
-		`show vitess_shards like %"`+psc.Database+`%;`,
+		`show vitess_shards like "%`+psc.Database+`%";`,
 	)
 	if err != nil {
 		return shards, errors.Wrap(err, "Unable to query database for shards")


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@planetscale.com>

- used prepared queries where possible (everything except `show` I think)
- normalize query case for grepping
- pass Go contexts where possible
- check all Go scanning errors