### PR TITLE
Always pick Primary Tablet

### DIFF
--- a/cmd/airbyte-source/read.go
+++ b/cmd/airbyte-source/read.go
@@ -68,6 +68,11 @@ func ReadCommand(ch *Helper) *cobra.Command {
 				os.Exit(1)
 			}
 
+			if len(catalog.Streams) == 0 {
+				ch.Logger.Log(internal.LOGLEVEL_ERROR, "catalog has no streams")
+				return
+			}
+
 			state := ""
 			if stateFilePath != "" {
 				b, err := ioutil.ReadFile(stateFilePath)

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -126,20 +126,6 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, w io.Writer, ps Plane
 	)
 
 	tabletType := psdbconnect.TabletType_primary
-	willNeverMatch := "phani"
-	if tc.Shard == willNeverMatch {
-		// TODO : fix https://github.com/planetscale/issues/issues/296
-		// We make all non default keyspaces connect to the PRIMARY.
-		if p.supportsTabletType(ctx, ps, "", psdbconnect.TabletType_replica) {
-			tabletType = psdbconnect.TabletType_replica
-		}
-	}
-
-	p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("picking tablet type : [%s]", strings.ToUpper(TabletTypeToString(tabletType))))
-	if tabletType == psdbconnect.TabletType_primary {
-		p.Logger.Log(LOGLEVEL_WARN, "Connecting to the primary to download data might cause performance issues with your database")
-	}
-
 	table := s.Stream
 	readDuration := 1 * time.Minute
 	peekCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -281,32 +267,4 @@ func (p PlanetScaleEdgeDatabase) printQueryResult(qr *sqltypes.Result, tableName
 	for _, record := range data {
 		p.Logger.Record(tableNamespace, tableName, record)
 	}
-}
-
-func (p PlanetScaleEdgeDatabase) supportsTabletType(ctx context.Context, psc PlanetScaleSource, shardName string, tt psdbconnect.TabletType) bool {
-
-	if err := p.CanConnect(ctx, psc); err != nil {
-		return false
-	}
-
-	tablets, err := p.Mysql.GetVitessTablets(ctx, psc)
-	if err != nil {
-		return false
-	}
-
-	for _, tablet := range tablets {
-		keyspaceHasTablet := strings.EqualFold(tablet.Keyspace, psc.Database)
-		tabletTypeIsServing := keyspaceHasTablet && strings.EqualFold(tablet.TabletType, TabletTypeToString(tt)) && strings.EqualFold(tablet.State, "SERVING")
-		matchesShardName := true
-
-		if shardName != "" {
-			matchesShardName = strings.EqualFold(tablet.Shard, shardName)
-		}
-
-		if keyspaceHasTablet && tabletTypeIsServing && matchesShardName {
-			return true
-		}
-	}
-
-	return false
 }

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -57,8 +57,8 @@ func TestRead_CanPeekBeforeRead(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, esc, sc)
 	assert.Equal(t, 3, cc.syncFnInvokedCount)
-	assert.True(t, tma.PingContextFnInvoked)
-	assert.True(t, tma.GetVitessTabletsFnInvoked)
+	assert.False(t, tma.PingContextFnInvoked)
+	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
 
 func TestRead_CanEarlyExitIfNoRecordsInPeek(t *testing.T) {
@@ -146,7 +146,7 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
 
-func TestRead_CanPickReplicaForUnshardedKeyspaces(t *testing.T) {
+func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 	tma := getTestMysqlAccess()
 	b := bytes.NewBufferString("")
 	ped := PlanetScaleEdgeDatabase{
@@ -165,7 +165,7 @@ func TestRead_CanPickReplicaForUnshardedKeyspaces(t *testing.T) {
 
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
-			assert.Equal(t, psdbconnect.TabletType_replica, in.TabletType)
+			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
 			return syncClient, nil
 		},
 	}
@@ -187,8 +187,8 @@ func TestRead_CanPickReplicaForUnshardedKeyspaces(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, esc, sc)
 	assert.Equal(t, 1, cc.syncFnInvokedCount)
-	assert.True(t, tma.PingContextFnInvoked)
-	assert.True(t, tma.GetVitessTabletsFnInvoked)
+	assert.False(t, tma.PingContextFnInvoked)
+	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
 
 func TestRead_CanReturnOriginalCursorIfNoNewFound(t *testing.T) {
@@ -210,7 +210,7 @@ func TestRead_CanReturnOriginalCursorIfNoNewFound(t *testing.T) {
 
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
-			assert.Equal(t, psdbconnect.TabletType_replica, in.TabletType)
+			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
 			return syncClient, nil
 		},
 	}
@@ -261,7 +261,7 @@ func TestRead_CanReturnNewCursorIfNewFound(t *testing.T) {
 
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
-			assert.Equal(t, psdbconnect.TabletType_replica, in.TabletType)
+			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
 			return syncClient, nil
 		},
 	}
@@ -321,7 +321,7 @@ func TestRead_CanLogResults(t *testing.T) {
 
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
-			assert.Equal(t, psdbconnect.TabletType_replica, in.TabletType)
+			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
 			return syncClient, nil
 		},
 	}


### PR DESCRIPTION
We've found a few issues with picking the replica when streaming changes down with Vstream: 
1. Cannot pick replica for sharded databases because it might be a cross-cell stream 
2. Cannot pick replica for  databases on a newer version of mysql

In light of this, we've decided to always pick the PRIMARY tablet for a given database for the beta launch.