### PR TITLE
Add support for custom airbyte types. 

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -97,16 +97,20 @@ func (p PlanetScaleEdgeDatabase) getStreamForTable(ctx context.Context, psc Plan
 }
 
 // Convert columnType to Airbyte type.
-func getJsonSchemaType(mysqlType string) string {
+func getJsonSchemaType(mysqlType string) PropertyType {
 	if strings.HasPrefix(mysqlType, "int") {
-		return "integer"
+		return PropertyType{Type: "integer"}
+	}
+
+	if strings.HasPrefix(mysqlType, "bigint") {
+		return PropertyType{Type: "string", AirbyteType: "big_integer"}
 	}
 
 	if mysqlType == "tinyint(1)" {
-		return "boolean"
+		return PropertyType{Type: "boolean"}
 	}
 
-	return "string"
+	return PropertyType{Type: "string"}
 }
 
 func (p PlanetScaleEdgeDatabase) Close() error {

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bytes"
 	"context"
+	"fmt"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -146,6 +147,68 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
 
+func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
+	var tests = []struct {
+		MysqlType      string
+		JSONSchemaType string
+		AirbyteType    string
+	}{
+		{
+			MysqlType:      "int(32)",
+			JSONSchemaType: "integer",
+			AirbyteType:    "",
+		},
+		{
+			MysqlType:      "tinyint(1)",
+			JSONSchemaType: "boolean",
+			AirbyteType:    "",
+		},
+		{
+			MysqlType:      "bigint(16)",
+			JSONSchemaType: "string",
+			AirbyteType:    "big_integer",
+		},
+		{
+			MysqlType:      "bigint unsigned",
+			JSONSchemaType: "string",
+			AirbyteType:    "big_integer",
+		},
+		{
+			MysqlType:      "bigint zerofill",
+			JSONSchemaType: "string",
+			AirbyteType:    "big_integer",
+		},
+		{
+			MysqlType:      "datetime",
+			JSONSchemaType: "string",
+			AirbyteType:    "timestamp_with_timezone",
+		},
+		{
+			MysqlType:      "date",
+			JSONSchemaType: "string",
+			AirbyteType:    "date",
+		},
+		{
+			MysqlType:      "text",
+			JSONSchemaType: "string",
+			AirbyteType:    "",
+		},
+		{
+			MysqlType:      "varchar(256)",
+			JSONSchemaType: "string",
+			AirbyteType:    "",
+		},
+	}
+
+	for _, typeTest := range tests {
+
+		t.Run(fmt.Sprintf("mysql_type_%v", typeTest.MysqlType), func(t *testing.T) {
+			p := getJsonSchemaType(typeTest.MysqlType)
+			assert.Equal(t, typeTest.AirbyteType, p.AirbyteType)
+			assert.Equal(t, typeTest.JSONSchemaType, p.Type)
+		})
+	}
+}
 func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 	tma := getTestMysqlAccess()
 	b := bytes.NewBufferString("")

--- a/cmd/internal/planetscale_edge_mysql.go
+++ b/cmd/internal/planetscale_edge_mysql.go
@@ -155,7 +155,7 @@ func (p planetScaleEdgeMySQLAccess) GetTableSchema(ctx context.Context, psc Plan
 			return properties, errors.Wrapf(err, "Unable to scan row for column names & types of table %v", tableName)
 		}
 
-		properties[name] = PropertyType{getJsonSchemaType(columnType)}
+		properties[name] = getJsonSchemaType(columnType)
 	}
 
 	if err := columnNamesQR.Err(); err != nil {

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -49,7 +49,7 @@ const (
 
 type PropertyType struct {
 	Type        string `json:"type"`
-	AirbyteType string `json:"airbyte_type"`
+	AirbyteType string `json:"airbyte_type,omitempty"`
 }
 
 type StreamSchema struct {

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -48,7 +48,8 @@ const (
 )
 
 type PropertyType struct {
-	Type string `json:"type"`
+	Type        string `json:"type"`
+	AirbyteType string `json:"airbyte_type"`
 }
 
 type StreamSchema struct {


### PR DESCRIPTION
Along with the 6 types defined in JSONSchema.org, Airbyte also supports its own types in the `Stream` properties section.
https://docs.airbyte.com/understanding-airbyte/supported-data-types/

This PR adds support for the airbyte types and adds a few tests for the same. 