### PR TITLE
Remove peek functionality and add more tests

### DIFF
--- a/cmd/airbyte-source/helper.go
+++ b/cmd/airbyte-source/helper.go
@@ -40,10 +40,6 @@ func (h *Helper) EnsureDB(psc internal.PlanetScaleSource) error {
 	if err != nil {
 		return err
 	}
-	h.Database = internal.PlanetScaleEdgeDatabase{
-		Logger: h.Logger,
-		Mysql:  mysql,
-	}
-
+	h.Database = internal.NewPlanetScaleEdgeDatabase(h.Logger, mysql)
 	return nil
 }

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -3,110 +3,24 @@ package internal
 import (
 	"bytes"
 	"context"
+	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"os"
 	"testing"
+	"time"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/proto/query"
 )
-
-func TestRead_CanPeekBeforeRead(t *testing.T) {
-	tma := getTestMysqlAccess()
-	b := bytes.NewBufferString("")
-	ped := PlanetScaleEdgeDatabase{
-		Logger: NewLogger(b),
-		Mysql:  tma,
-	}
-	tc := &psdbconnect.TableCursor{
-		Shard:    "-",
-		Position: "THIS_IS_A_SHARD_GTID",
-		Keyspace: "connect-test",
-	}
-
-	syncClient := &connectSyncClientMock{
-		syncResponses: []*psdbconnect.SyncResponse{
-			{
-				Cursor: tc,
-			},
-			{
-				Cursor: tc,
-			},
-		},
-	}
-
-	cc := clientConnectionMock{
-		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
-			return syncClient, nil
-		},
-	}
-	ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
-		return &cc, nil
-	}
-	ps := PlanetScaleSource{}
-	cs := ConfiguredStream{
-		Stream: Stream{
-			Name:      "customers",
-			Namespace: "connect-test",
-		},
-	}
-	sc, err := ped.Read(context.Background(), os.Stdout, ps, cs, tc)
-	assert.NoError(t, err)
-	esc, err := TableCursorToSerializedCursor(tc)
-	assert.NoError(t, err)
-	assert.Equal(t, esc, sc)
-	assert.Equal(t, 3, cc.syncFnInvokedCount)
-	assert.False(t, tma.PingContextFnInvoked)
-	assert.False(t, tma.GetVitessTabletsFnInvoked)
-}
-
-func TestRead_CanEarlyExitIfNoRecordsInPeek(t *testing.T) {
-	tma := getTestMysqlAccess()
-	b := bytes.NewBufferString("")
-	ped := PlanetScaleEdgeDatabase{
-		Logger: NewLogger(b),
-		Mysql:  tma,
-	}
-	tc := &psdbconnect.TableCursor{
-		Shard:    "-",
-		Position: "THIS_IS_A_SHARD_GTID",
-		Keyspace: "connect-test",
-	}
-
-	syncClient := &connectSyncClientMock{
-		syncResponses: []*psdbconnect.SyncResponse{},
-	}
-
-	cc := clientConnectionMock{
-		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
-			return syncClient, nil
-		},
-	}
-	ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
-		return &cc, nil
-	}
-	ps := PlanetScaleSource{}
-	cs := ConfiguredStream{
-		Stream: Stream{
-			Name:      "customers",
-			Namespace: "connect-test",
-		},
-	}
-	sc, err := ped.Read(context.Background(), os.Stdout, ps, cs, tc)
-	assert.NoError(t, err)
-	esc, err := TableCursorToSerializedCursor(tc)
-	assert.NoError(t, err)
-	assert.Equal(t, esc, sc)
-	assert.Equal(t, 1, cc.syncFnInvokedCount)
-}
 
 func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 	tma := getTestMysqlAccess()
 	b := bytes.NewBufferString("")
 	ped := PlanetScaleEdgeDatabase{
-		Logger: NewLogger(b),
-		Mysql:  tma,
+		Logger:       NewLogger(b),
+		Mysql:        tma,
+		readDuration: 5 * time.Second,
 	}
 	tc := &psdbconnect.TableCursor{
 		Shard:    "40-80",
@@ -121,7 +35,7 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
 			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
-			return syncClient, nil
+			return syncClient, errors.New("all done")
 		},
 	}
 	ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
@@ -137,7 +51,7 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 		},
 	}
 	sc, err := ped.Read(context.Background(), os.Stdout, ps, cs, tc)
-	assert.NoError(t, err)
+	assert.ErrorContains(t, err, "all done")
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
 	assert.Equal(t, esc, sc)
@@ -150,8 +64,9 @@ func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 	tma := getTestMysqlAccess()
 	b := bytes.NewBufferString("")
 	ped := PlanetScaleEdgeDatabase{
-		Logger: NewLogger(b),
-		Mysql:  tma,
+		Logger:       NewLogger(b),
+		Mysql:        tma,
+		readDuration: 5 * time.Second,
 	}
 	tc := &psdbconnect.TableCursor{
 		Shard:    "-",
@@ -166,7 +81,7 @@ func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
 			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
-			return syncClient, nil
+			return syncClient, errors.New("all done")
 		},
 	}
 	ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
@@ -182,7 +97,7 @@ func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 		},
 	}
 	sc, err := ped.Read(context.Background(), os.Stdout, ps, cs, tc)
-	assert.NoError(t, err)
+	assert.ErrorContains(t, err, "all done")
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
 	assert.Equal(t, esc, sc)
@@ -195,8 +110,9 @@ func TestRead_CanReturnOriginalCursorIfNoNewFound(t *testing.T) {
 	tma := getTestMysqlAccess()
 	b := bytes.NewBufferString("")
 	ped := PlanetScaleEdgeDatabase{
-		Logger: NewLogger(b),
-		Mysql:  tma,
+		Logger:       NewLogger(b),
+		Mysql:        tma,
+		readDuration: 5 * time.Second,
 	}
 	tc := &psdbconnect.TableCursor{
 		Shard:    "-",
@@ -211,7 +127,7 @@ func TestRead_CanReturnOriginalCursorIfNoNewFound(t *testing.T) {
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
 			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
-			return syncClient, nil
+			return syncClient, errors.New("all done")
 		},
 	}
 	ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
@@ -227,7 +143,7 @@ func TestRead_CanReturnOriginalCursorIfNoNewFound(t *testing.T) {
 		},
 	}
 	sc, err := ped.Read(context.Background(), os.Stdout, ps, cs, tc)
-	assert.NoError(t, err)
+	assert.ErrorContains(t, err, "all done")
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
 	assert.Equal(t, esc, sc)
@@ -238,8 +154,9 @@ func TestRead_CanReturnNewCursorIfNewFound(t *testing.T) {
 	tma := getTestMysqlAccess()
 	b := bytes.NewBufferString("")
 	ped := PlanetScaleEdgeDatabase{
-		Logger: NewLogger(b),
-		Mysql:  tma,
+		Logger:       NewLogger(b),
+		Mysql:        tma,
+		readDuration: 5 * time.Second,
 	}
 	tc := &psdbconnect.TableCursor{
 		Shard:    "-",
@@ -282,15 +199,198 @@ func TestRead_CanReturnNewCursorIfNewFound(t *testing.T) {
 	esc, err := TableCursorToSerializedCursor(newTC)
 	assert.NoError(t, err)
 	assert.Equal(t, esc, sc)
-	assert.Equal(t, 3, cc.syncFnInvokedCount)
+	assert.Equal(t, 1, cc.syncFnInvokedCount)
+}
+
+func TestRead_CanContinueAfterDeadlineExceeded(t *testing.T) {
+	tma := getTestMysqlAccess()
+	tal := &testAirbyteLogger{}
+	//b := bytes.NewBufferString("")
+	ped := PlanetScaleEdgeDatabase{
+		Logger:       tal,
+		Mysql:        tma,
+		readDuration: 5 * time.Second,
+	}
+	tc := &psdbconnect.TableCursor{
+		Shard:    "-",
+		Position: "THIS_IS_A_SHARD_GTID",
+		Keyspace: "connect-test",
+	}
+	newTC := &psdbconnect.TableCursor{
+		Shard:    "-",
+		Position: "I_AM_FARTHER_IN_THE_BINLOG",
+		Keyspace: "connect-test",
+	}
+
+	// by default connectSyncClientMock returns an io.EOF when there are no
+	// more responses to send.
+	syncClient := &connectSyncClientMock{
+		sendDeadLineExceeded: true,
+		syncResponses: []*psdbconnect.SyncResponse{
+			{Cursor: newTC},
+		},
+	}
+
+	cc := clientConnectionMock{
+		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
+			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
+			return syncClient, nil
+		},
+	}
+	ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
+		return &cc, nil
+	}
+	ps := PlanetScaleSource{
+		Database: "connect-test",
+	}
+	cs := ConfiguredStream{
+		Stream: Stream{
+			Name:      "customers",
+			Namespace: "connect-test",
+		},
+	}
+
+	sc, err := ped.Read(context.Background(), os.Stdout, ps, cs, tc)
+	assert.NoError(t, err)
+	logLines := tal.logMessages[LOGLEVEL_INFO]
+	// a DeadLineExceeded error means that the server timed out and that the client can retry.
+	continueMessageFound := false
+	for _, line := range logLines {
+		continueMessageFound = continueMessageFound || line == "Continuing with cursor after server timeout"
+	}
+	assert.True(t, continueMessageFound, "Should continue after Server disconnects")
+	// an io.EOF should mean that the server is done syncing all rows for this table.
+	assert.Contains(t, logLines[len(logLines)-1], "Done synchronizing rows for stream [customers]")
+	esc, err := TableCursorToSerializedCursor(newTC)
+	assert.NoError(t, err)
+	assert.Equal(t, esc, sc)
+	assert.Equal(t, 2, cc.syncFnInvokedCount)
+}
+
+func TestRead_CanEndRecvAfterNonDeadlineExceeded(t *testing.T) {
+	tma := getTestMysqlAccess()
+	tal := &testAirbyteLogger{}
+	//b := bytes.NewBufferString("")
+	ped := PlanetScaleEdgeDatabase{
+		Logger:       tal,
+		Mysql:        tma,
+		readDuration: 5 * time.Second,
+	}
+	tc := &psdbconnect.TableCursor{
+		Shard:    "-",
+		Position: "THIS_IS_A_SHARD_GTID",
+		Keyspace: "connect-test",
+	}
+	newTC := &psdbconnect.TableCursor{
+		Shard:    "-",
+		Position: "I_AM_FARTHER_IN_THE_BINLOG",
+		Keyspace: "connect-test",
+	}
+
+	// by default connectSyncClientMock returns an io.EOF when there are no
+	// more responses to send.
+	syncClient := &connectSyncClientMock{
+		sendNonEOF: true,
+		syncResponses: []*psdbconnect.SyncResponse{
+			{Cursor: newTC},
+		},
+	}
+
+	cc := clientConnectionMock{
+		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
+			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
+			return syncClient, nil
+		},
+	}
+	ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
+		return &cc, nil
+	}
+	ps := PlanetScaleSource{
+		Database: "connect-test",
+	}
+	cs := ConfiguredStream{
+		Stream: Stream{
+			Name:      "customers",
+			Namespace: "connect-test",
+		},
+	}
+
+	sc, err := ped.Read(context.Background(), os.Stdout, ps, cs, tc)
+	assert.NoError(t, err)
+	logLines := tal.logMessages[LOGLEVEL_INFO]
+	// an io.EOF should mean that the server is done syncing all rows for this table.
+	assert.Contains(t, logLines[len(logLines)-1], "Got error [FailedPrecondition], Returning with cursor")
+	esc, err := TableCursorToSerializedCursor(newTC)
+	assert.NoError(t, err)
+	assert.Equal(t, esc, sc)
+	assert.Equal(t, 1, cc.syncFnInvokedCount)
+}
+
+func TestRead_CanEndRecvAfterEof(t *testing.T) {
+	tma := getTestMysqlAccess()
+	tal := &testAirbyteLogger{}
+	//b := bytes.NewBufferString("")
+	ped := PlanetScaleEdgeDatabase{
+		Logger:       tal,
+		Mysql:        tma,
+		readDuration: 5 * time.Second,
+	}
+	tc := &psdbconnect.TableCursor{
+		Shard:    "-",
+		Position: "THIS_IS_A_SHARD_GTID",
+		Keyspace: "connect-test",
+	}
+	newTC := &psdbconnect.TableCursor{
+		Shard:    "-",
+		Position: "I_AM_FARTHER_IN_THE_BINLOG",
+		Keyspace: "connect-test",
+	}
+
+	// by default connectSyncClientMock returns an io.EOF when there are no
+	// more responses to send.
+	syncClient := &connectSyncClientMock{
+		syncResponses: []*psdbconnect.SyncResponse{
+			{Cursor: newTC},
+		},
+	}
+
+	cc := clientConnectionMock{
+		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
+			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
+			return syncClient, nil
+		},
+	}
+	ped.clientFn = func(ctx context.Context, ps PlanetScaleSource) (psdbconnect.ConnectClient, error) {
+		return &cc, nil
+	}
+	ps := PlanetScaleSource{
+		Database: "connect-test",
+	}
+	cs := ConfiguredStream{
+		Stream: Stream{
+			Name:      "customers",
+			Namespace: "connect-test",
+		},
+	}
+
+	sc, err := ped.Read(context.Background(), os.Stdout, ps, cs, tc)
+	assert.NoError(t, err)
+	logLines := tal.logMessages[LOGLEVEL_INFO]
+	// an io.EOF should mean that the server is done syncing all rows for this table.
+	assert.Equal(t, "Done synchronizing rows for stream [customers]", logLines[len(logLines)-1])
+	esc, err := TableCursorToSerializedCursor(newTC)
+	assert.NoError(t, err)
+	assert.Equal(t, esc, sc)
+	assert.Equal(t, 1, cc.syncFnInvokedCount)
 }
 
 func TestRead_CanLogResults(t *testing.T) {
 	tma := getTestMysqlAccess()
 	tal := testAirbyteLogger{}
 	ped := PlanetScaleEdgeDatabase{
-		Logger: &tal,
-		Mysql:  tma,
+		Logger:       &tal,
+		Mysql:        tma,
+		readDuration: 5 * time.Second,
 	}
 	tc := &psdbconnect.TableCursor{
 		Shard:    "-",
@@ -314,7 +414,6 @@ func TestRead_CanLogResults(t *testing.T) {
 
 	syncClient := &connectSyncClientMock{
 		syncResponses: []*psdbconnect.SyncResponse{
-			{Cursor: newTC, Result: result},
 			{Cursor: newTC, Result: result},
 		},
 	}


### PR DESCRIPTION
While running tests against a very large database with >20M rows, we've seen that the `peek` functionality, which uses a timeout of 5 seconds, isn't working correctly. 
VStream might take more than 5 seconds to return a response of whether or not there are more rows after a VGTID, which meant that we were missing rows when syncing. 
This PR removes the `peek` functionality and adds a few tests for the various exit scenarios of the `READ` command. 