### PR TITLE
Increase peek timeout to 45 seconds

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -182,7 +182,7 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 	defer p.Logger.Flush()
 	timeout := 1 * time.Minute
 	if peek {
-		timeout = 5 * time.Second
+		timeout = 45 * time.Second
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)


### PR DESCRIPTION
This should give vstream enough time to tell us if there's more rows to sync, even for very very large tables. 