### PR TITLE
Use current vgtid as a stopping point for sync sessions.

### DIFF
--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -57,12 +57,12 @@ func TestRead_CanPeekBeforeRead(t *testing.T) {
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
 	assert.Equal(t, esc, sc)
-	assert.Equal(t, 3, cc.syncFnInvokedCount)
+	assert.Equal(t, 1, cc.syncFnInvokedCount)
 	assert.False(t, tma.PingContextFnInvoked)
 	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
 
-func TestRead_CanEarlyExitIfNoRecordsInPeek(t *testing.T) {
+func TestRead_CanEarlyExitIfNoNewVGtidInPeek(t *testing.T) {
 	tma := getTestMysqlAccess()
 	b := bytes.NewBufferString("")
 	ped := PlanetScaleEdgeDatabase{
@@ -76,7 +76,9 @@ func TestRead_CanEarlyExitIfNoRecordsInPeek(t *testing.T) {
 	}
 
 	syncClient := &connectSyncClientMock{
-		syncResponses: []*psdbconnect.SyncResponse{},
+		syncResponses: []*psdbconnect.SyncResponse{
+			{Cursor: tc},
+		},
 	}
 
 	cc := clientConnectionMock{
@@ -223,7 +225,11 @@ func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 	}
 
 	syncClient := &connectSyncClientMock{
-		syncResponses: []*psdbconnect.SyncResponse{},
+		syncResponses: []*psdbconnect.SyncResponse{
+			{
+				Cursor: tc,
+			},
+		},
 	}
 
 	cc := clientConnectionMock{
@@ -268,7 +274,9 @@ func TestRead_CanReturnOriginalCursorIfNoNewFound(t *testing.T) {
 	}
 
 	syncClient := &connectSyncClientMock{
-		syncResponses: []*psdbconnect.SyncResponse{},
+		syncResponses: []*psdbconnect.SyncResponse{
+			{Cursor: tc},
+		},
 	}
 
 	cc := clientConnectionMock{
@@ -345,7 +353,7 @@ func TestRead_CanReturnNewCursorIfNewFound(t *testing.T) {
 	esc, err := TableCursorToSerializedCursor(newTC)
 	assert.NoError(t, err)
 	assert.Equal(t, esc, sc)
-	assert.Equal(t, 3, cc.syncFnInvokedCount)
+	assert.Equal(t, 2, cc.syncFnInvokedCount)
 }
 
 func TestRead_CanLogResults(t *testing.T) {


### PR DESCRIPTION
Currently, we start a sync session with vstream and just wait until the timeout stops the sync session. 
This is causing us to spin forever with high-traffic tables such as the `query insights` database powering PlanetScale's Query Insights feature. 
The current workflow is : 
1. Read last known cursor, ask to stream from here. 
2. When a stream session is interrupted after the server timeout, ask for the last cursor. 
3. Use this last cursor to see if there are any more rows. 
4. Keep streaming if there's more rows. 
Because of the pattern of traffic to some databases, `#3` will always return true, leading to a never-ending sync session.

To fix this, we will make a few changes to _how_ we sync and _when_ we stop. 
1. Instead of asking if there are more rows from a given position, we will get the `latest vgtid` for a given table in a shard when a sync session starts. 
2. This `latest vgtid` is now the stopping point for this sync session. 
3. Ask vstream to stream from the `last known vgtid`
4. When we reach the stopping point, read all rows available at this vgtid
5. End the stream when (a) a vgtid newer than  `latest vgtid` is encountered or (b) the timeout kicks in.
