### PR TITLE
Ensure that all rows are printed before exiting 

### DIFF
--- a/cmd/internal/planetscale_connection.go
+++ b/cmd/internal/planetscale_connection.go
@@ -56,8 +56,8 @@ func (psc PlanetScaleSource) GetInitialState(keyspaceOrDatabase string, shards [
 		}
 
 		// if we got this far, all the shards that the customer asked for exist in the PlanetScale database.
-		filteredShards := make([]string, len(foundShards))
-		for key := range foundShards {
+		filteredShards := make([]string, len(configuredShards))
+		for _, key := range configuredShards {
 			filteredShards = append(filteredShards, key)
 		}
 		shards = filteredShards

--- a/cmd/internal/planetscale_connection.go
+++ b/cmd/internal/planetscale_connection.go
@@ -56,9 +56,11 @@ func (psc PlanetScaleSource) GetInitialState(keyspaceOrDatabase string, shards [
 		}
 
 		// if we got this far, all the shards that the customer asked for exist in the PlanetScale database.
-		filteredShards := make([]string, len(configuredShards))
+		filteredShards := make([]string, 0, len(configuredShards))
 		for _, key := range configuredShards {
-			filteredShards = append(filteredShards, key)
+			if len(configuredShards) > 0 {
+				filteredShards = append(filteredShards, key)
+			}
 		}
 		shards = filteredShards
 	}

--- a/cmd/internal/planetscale_connection.go
+++ b/cmd/internal/planetscale_connection.go
@@ -50,19 +50,15 @@ func (psc PlanetScaleSource) GetInitialState(keyspaceOrDatabase string, shards [
 		}
 
 		for _, configuredShard := range configuredShards {
-			if _, ok := foundShards[strings.TrimSpace(configuredShard)]; !ok {
-				return shardCursors, fmt.Errorf("shard %v does not exist on the source database", configuredShard)
+			if len(configuredShard) > 0 {
+				if _, ok := foundShards[strings.TrimSpace(configuredShard)]; !ok {
+					return shardCursors, fmt.Errorf("shard %v does not exist on the source database", configuredShard)
+				}
 			}
 		}
 
 		// if we got this far, all the shards that the customer asked for exist in the PlanetScale database.
-		filteredShards := make([]string, 0, len(configuredShards))
-		for _, key := range configuredShards {
-			if len(configuredShards) > 0 {
-				filteredShards = append(filteredShards, key)
-			}
-		}
-		shards = filteredShards
+		shards = configuredShards
 	}
 
 	for _, shard := range shards {

--- a/cmd/internal/planetscale_connection_test.go
+++ b/cmd/internal/planetscale_connection_test.go
@@ -61,6 +61,43 @@ func TestCanGenerateInitialState_Sharded(t *testing.T) {
 	assert.Equal(t, expectedShardStates, shardStates)
 }
 
+func TestCanGenerateInitialState_CustomShards(t *testing.T) {
+	psc := PlanetScaleSource{
+		Host:     "useast.psdb.connect",
+		Username: "usernameus-east-4",
+		Password: "pscale_password",
+		Database: "connect-test",
+		Shards:   "80-c0",
+	}
+	shards := []string{
+		"-40",
+		"40-80",
+		"80-c0",
+		"c0-",
+	}
+
+	configuredShards := []string{"80-c0"}
+	shardStates, err := psc.GetInitialState("connect-test", shards)
+	assert.NoError(t, err)
+	assert.Equal(t, len(configuredShards), len(shardStates.Shards))
+
+	expectedShardStates := ShardStates{
+		Shards: map[string]*SerializedCursor{},
+	}
+
+	for _, shard := range configuredShards {
+		expectedShardStates.Shards[shard], err = TableCursorToSerializedCursor(&psdbconnect.TableCursor{
+			Shard:    shard,
+			Keyspace: "connect-test",
+			Position: "",
+		})
+		assert.NoError(t, err)
+	}
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedShardStates, shardStates)
+}
+
 func TestCanGenerateInitialState_Unsharded(t *testing.T) {
 	psc := PlanetScaleSource{
 		Host:     "useast.psdb.connect",

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -267,10 +267,6 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 		// if we get a newer vgtid.
 		watchForVgGtidChange = watchForVgGtidChange || tc.Position == stopPosition
 
-		if watchForVgGtidChange && tc.Position != stopPosition {
-			return tc, io.EOF
-		}
-
 		if len(res.Result) > 0 {
 			for _, result := range res.Result {
 				qr := sqltypes.Proto3ToResult(result)
@@ -285,6 +281,9 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 			}
 		}
 
+		if watchForVgGtidChange && tc.Position != stopPosition {
+			return tc, io.EOF
+		}
 	}
 }
 

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -368,28 +368,32 @@ func TestRead_CanStopAtWellKnownCursor(t *testing.T) {
 
 	numResponses := 10
 	// when the client tries to get the "current" vgtid,
-	// we return the penultimate element of the array.
-	currentVGtidPosition := numResponses - 2
+	// we return the ante-penultimate element of the array.
+	currentVGtidPosition := (numResponses * 3) - 4
 	// this is the next vgtid that should stop the sync session.
 	nextVGtidPosition := currentVGtidPosition + 1
 	responses := make([]*psdbconnect.SyncResponse, 0, numResponses)
 	for i := 0; i < numResponses; i++ {
 		// this simulates multiple events being returned, for the same vgtid, from vstream
 		for x := 0; x < 3; x++ {
-
-			result := []*query.QueryResult{
-				sqltypes.ResultToProto3(sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-					"pid|description",
-					"int64|varbinary"),
-					fmt.Sprintf("%v|keyboard", i+1),
-					fmt.Sprintf("%v|monitor", i+2),
-				)),
+			var result []*query.QueryResult
+			if x == 2 {
+				result = []*query.QueryResult{
+					sqltypes.ResultToProto3(sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+						"pid|description",
+						"int64|varbinary"),
+						fmt.Sprintf("%v|keyboard", i+1),
+						fmt.Sprintf("%v|monitor", i+2),
+					)),
+				}
 			}
+
+			vgtid := fmt.Sprintf("e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", i)
 			responses = append(responses, &psdbconnect.SyncResponse{
 				Cursor: &psdbconnect.TableCursor{
 					Shard:    "-",
 					Keyspace: "connect-test",
-					Position: fmt.Sprintf("e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", i),
+					Position: vgtid,
 				},
 				Result: result,
 			})
@@ -429,6 +433,7 @@ func TestRead_CanStopAtWellKnownCursor(t *testing.T) {
 			Namespace: "connect-test",
 		},
 	}
+
 	sc, err := ped.Read(context.Background(), os.Stdout, ps, cs, responses[0].Cursor)
 	assert.NoError(t, err)
 	// sync should start at the first vgtid
@@ -440,7 +445,7 @@ func TestRead_CanStopAtWellKnownCursor(t *testing.T) {
 	logLines := tal.logMessages[LOGLEVEL_INFO]
 	assert.Equal(t, "[connect-test:customers shard : -] Finished reading all rows for table [customers]", logLines[len(logLines)-1])
 	records := tal.records["connect-test.customers"]
-	assert.Equal(t, numResponses*2, len(records))
+	assert.Equal(t, 2*(nextVGtidPosition/3), len(records))
 }
 
 func TestRead_CanLogResults(t *testing.T) {


### PR DESCRIPTION
When we run a sync operation, we capture the `current` cursor as the stopping point, this was implemented in #40 .
However, when we do hit the new cursor, we might have rows left over from the previous vgtid, and when we return immediately on the cursor changing, we miss those rows. 
This PR moves the exit block to **after** all rows at the stop vgtid are parsed and returns. 
