### PR TITLE
Output last key property as the default_cursor_field

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -89,8 +89,10 @@ func (p PlanetScaleEdgeDatabase) getStreamForTable(ctx context.Context, psc Plan
 	}
 	for _, key := range primaryKeys {
 		stream.PrimaryKeys = append(stream.PrimaryKeys, []string{key})
-		stream.DefaultCursorFields = append(stream.DefaultCursorFields, key)
 	}
+
+	// pick the last key field as the default cursor field.
+	stream.DefaultCursorFields = append(stream.DefaultCursorFields, primaryKeys[len(primaryKeys)-1])
 
 	stream.SourceDefinedCursor = true
 	return stream, nil


### PR DESCRIPTION
We used to output all known key properties in the `default_cursor_field` property.  But the `default_cursor_field` property is intended to point to a **single property name** with the elements in the array being path segments. 

### Before
``` json
"source_defined_primary_key": [
          [
            "emp_no"
          ],
          [
            "title"
          ],
          [
            "from_date"
          ]
        ],
        "source_defined_cursor": true,
        "default_cursor_field": [
         "emp_no",
          "title",
          "from_date"
        ]
```

Airbyte thought ☝🏾 referred to a property named `emp_no.title.from_date`, which is invalid, leading to : 

``` json
"internal_message": "Unsupported nested cursor field emp_no.title.from_date for stream employees"
```

### After
``` json
"source_defined_primary_key": [
          [
            "emp_no"
          ],
          [
            "title"
          ],
          [
            "from_date"
          ]
        ],
        "source_defined_cursor": true,
        "default_cursor_field": [
          "from_date"
        ]
```

The fix is to pick the last element in the primary key array and return that instead. Since the cursors are vgtids that are saved and tracked by vstream, and not properties on the records themselves.