### PR TITLE
Allow customers to choose how we treat TinyInt(1)

### DIFF
--- a/cmd/airbyte-source/spec.go
+++ b/cmd/airbyte-source/spec.go
@@ -62,11 +62,26 @@ func SpecCommand() *cobra.Command {
 								Type:        "string",
 								Order:       4,
 							},
-							DoNotTreatTinyIntAsBoolean: internal.ConnectionProperty{
-								Description: "If enabled, properties of type TinyInt(1) are output as TinyInt, and not boolean.",
-								Title:       "Do Not Treat TinyInt(1) as boolean",
-								Type:        "boolean",
+							Options: internal.CustomOptionsSpecification{
 								Order:       5,
+								Type:        "object",
+								Title:       "Custom configuration options",
+								Description: "Configuration options to customize PlanetScale source",
+								Options: []internal.CustomOptions{
+									{
+										Type:        "object",
+										Title:       "options",
+										Description: "options",
+										Properties: internal.CustomOptionsProperties{
+											DoNotTreatTinyIntAsBoolean: internal.ConnectionProperty{
+												Description: "If enabled, properties of type TinyInt(1) are output as TinyInt, and not boolean.",
+												Title:       "Do Not Treat TinyInt(1) as boolean",
+												Type:        "boolean",
+												Order:       5,
+											},
+										},
+									},
+								},
 							},
 						},
 					},

--- a/cmd/airbyte-source/spec.go
+++ b/cmd/airbyte-source/spec.go
@@ -62,6 +62,12 @@ func SpecCommand() *cobra.Command {
 								Type:        "string",
 								Order:       4,
 							},
+							DoNotTreatTinyIntAsBoolean: internal.ConnectionProperty{
+								Description: "If enabled, properties of type TinyInt(1) are output as TinyInt, and not boolean.",
+								Title:       "Do Not Treat TinyInt(1) as boolean",
+								Type:        "boolean",
+								Order:       5,
+							},
 						},
 					},
 				},

--- a/cmd/internal/planetscale_connection.go
+++ b/cmd/internal/planetscale_connection.go
@@ -10,11 +10,12 @@ import (
 
 // PlanetScaleSource defines a configured Airbyte Source for a PlanetScale database
 type PlanetScaleSource struct {
-	Host     string `json:"host"`
-	Database string `json:"database"`
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Shards   string `json:"shards"`
+	Host                       string `json:"host"`
+	Database                   string `json:"database"`
+	Username                   string `json:"username"`
+	Password                   string `json:"password"`
+	Shards                     string `json:"shards"`
+	DoNotTreatTinyIntAsBoolean bool   `json:"do_not_treat_tiny_int_as_boolean"`
 }
 
 // DSN returns a DataSource that mysql libraries can use to connect to a PlanetScale database.

--- a/cmd/internal/planetscale_connection.go
+++ b/cmd/internal/planetscale_connection.go
@@ -10,12 +10,16 @@ import (
 
 // PlanetScaleSource defines a configured Airbyte Source for a PlanetScale database
 type PlanetScaleSource struct {
-	Host                       string `json:"host"`
-	Database                   string `json:"database"`
-	Username                   string `json:"username"`
-	Password                   string `json:"password"`
-	Shards                     string `json:"shards"`
-	DoNotTreatTinyIntAsBoolean bool   `json:"do_not_treat_tiny_int_as_boolean"`
+	Host     string              `json:"host"`
+	Database string              `json:"database"`
+	Username string              `json:"username"`
+	Password string              `json:"password"`
+	Shards   string              `json:"shards"`
+	Options  CustomSourceOptions `json:"options"`
+}
+
+type CustomSourceOptions struct {
+	DoNotTreatTinyIntAsBoolean bool `json:"do_not_treat_tiny_int_as_boolean"`
 }
 
 // DSN returns a DataSource that mysql libraries can use to connect to a PlanetScale database.

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -101,7 +101,7 @@ func (p PlanetScaleEdgeDatabase) getStreamForTable(ctx context.Context, psc Plan
 }
 
 // Convert columnType to Airbyte type.
-func getJsonSchemaType(mysqlType string) PropertyType {
+func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool) PropertyType {
 	// Support custom airbyte types documented here :
 	// https://docs.airbyte.com/understanding-airbyte/supported-data-types/#the-types
 	if strings.HasPrefix(mysqlType, "int") {
@@ -116,9 +116,15 @@ func getJsonSchemaType(mysqlType string) PropertyType {
 		return PropertyType{Type: "string", AirbyteType: "timestamp_with_timezone"}
 	}
 
+	if mysqlType == "tinyint(1)" {
+		if treatTinyIntAsBoolean {
+			return PropertyType{Type: "boolean"}
+		}
+
+		return PropertyType{Type: "integer"}
+	}
+
 	switch mysqlType {
-	case "tinyint(1)":
-		return PropertyType{Type: "boolean"}
 	case "date":
 		return PropertyType{Type: "string", AirbyteType: "date"}
 	case "datetime":

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -153,9 +153,10 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 
 func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 	var tests = []struct {
-		MysqlType      string
-		JSONSchemaType string
-		AirbyteType    string
+		MysqlType             string
+		JSONSchemaType        string
+		AirbyteType           string
+		TreatTinyIntAsBoolean bool
 	}{
 		{
 			MysqlType:      "int(32)",
@@ -163,9 +164,16 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 			AirbyteType:    "",
 		},
 		{
-			MysqlType:      "tinyint(1)",
-			JSONSchemaType: "boolean",
-			AirbyteType:    "",
+			MysqlType:             "tinyint(1)",
+			JSONSchemaType:        "boolean",
+			AirbyteType:           "",
+			TreatTinyIntAsBoolean: true,
+		},
+		{
+			MysqlType:             "tinyint(1)",
+			JSONSchemaType:        "integer",
+			AirbyteType:           "",
+			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:      "bigint(16)",
@@ -207,7 +215,7 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 	for _, typeTest := range tests {
 
 		t.Run(fmt.Sprintf("mysql_type_%v", typeTest.MysqlType), func(t *testing.T) {
-			p := getJsonSchemaType(typeTest.MysqlType)
+			p := getJsonSchemaType(typeTest.MysqlType, typeTest.TreatTinyIntAsBoolean)
 			assert.Equal(t, typeTest.AirbyteType, p.AirbyteType)
 			assert.Equal(t, typeTest.JSONSchemaType, p.Type)
 		})

--- a/cmd/internal/planetscale_edge_mysql.go
+++ b/cmd/internal/planetscale_edge_mysql.go
@@ -155,7 +155,7 @@ func (p planetScaleEdgeMySQLAccess) GetTableSchema(ctx context.Context, psc Plan
 			return properties, errors.Wrapf(err, "Unable to scan row for column names & types of table %v", tableName)
 		}
 
-		properties[name] = getJsonSchemaType(columnType)
+		properties[name] = getJsonSchemaType(columnType, !psc.DoNotTreatTinyIntAsBoolean)
 	}
 
 	if err := columnNamesQR.Err(); err != nil {

--- a/cmd/internal/planetscale_edge_mysql.go
+++ b/cmd/internal/planetscale_edge_mysql.go
@@ -155,7 +155,7 @@ func (p planetScaleEdgeMySQLAccess) GetTableSchema(ctx context.Context, psc Plan
 			return properties, errors.Wrapf(err, "Unable to scan row for column names & types of table %v", tableName)
 		}
 
-		properties[name] = getJsonSchemaType(columnType, !psc.DoNotTreatTinyIntAsBoolean)
+		properties[name] = getJsonSchemaType(columnType, !psc.Options.DoNotTreatTinyIntAsBoolean)
 	}
 
 	if err := columnNamesQR.Err(); err != nil {

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -166,11 +166,12 @@ type SpecMessage struct {
 }
 
 type ConnectionProperties struct {
-	Host     ConnectionProperty `json:"host"`
-	Shards   ConnectionProperty `json:"shards"`
-	Database ConnectionProperty `json:"database"`
-	Username ConnectionProperty `json:"username"`
-	Password ConnectionProperty `json:"password"`
+	Host                       ConnectionProperty `json:"host"`
+	Shards                     ConnectionProperty `json:"shards"`
+	Database                   ConnectionProperty `json:"database"`
+	Username                   ConnectionProperty `json:"username"`
+	Password                   ConnectionProperty `json:"password"`
+	DoNotTreatTinyIntAsBoolean ConnectionProperty `json:"do_not_treat_tiny_int_as_boolean"`
 }
 
 type ConnectionProperty struct {

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -165,13 +165,45 @@ type SpecMessage struct {
 	Spec Spec   `json:"spec"`
 }
 
-type ConnectionProperties struct {
-	Host                       ConnectionProperty `json:"host"`
-	Shards                     ConnectionProperty `json:"shards"`
-	Database                   ConnectionProperty `json:"database"`
-	Username                   ConnectionProperty `json:"username"`
-	Password                   ConnectionProperty `json:"password"`
+type ConnectionPropertyHash struct {
+	Description string                             `json:"description"`
+	Title       string                             `json:"title"`
+	Type        string                             `json:"type"`
+	Order       int                                `json:"order"`
+	Options     []ConnectionPropertyHashProperties `json:"oneOf"`
+}
+
+type ConnectionPropertyHashProperties struct {
 	DoNotTreatTinyIntAsBoolean ConnectionProperty `json:"do_not_treat_tiny_int_as_boolean"`
+}
+
+type CustomOptionsSpecification struct {
+	Description string          `json:"description"`
+	Title       string          `json:"title"`
+	Type        string          `json:"type"`
+	Order       int             `json:"order"`
+	Options     []CustomOptions `json:"oneOf"`
+}
+
+type CustomOptions struct {
+	Description string                  `json:"description"`
+	Title       string                  `json:"title"`
+	Type        string                  `json:"type"`
+	Order       int                     `json:"order"`
+	Properties  CustomOptionsProperties `json:"properties"`
+}
+
+type CustomOptionsProperties struct {
+	DoNotTreatTinyIntAsBoolean ConnectionProperty `json:"do_not_treat_tiny_int_as_boolean"`
+}
+
+type ConnectionProperties struct {
+	Host     ConnectionProperty         `json:"host"`
+	Shards   ConnectionProperty         `json:"shards"`
+	Database ConnectionProperty         `json:"database"`
+	Username ConnectionProperty         `json:"username"`
+	Password ConnectionProperty         `json:"password"`
+	Options  CustomOptionsSpecification `json:"options"`
 }
 
 type ConnectionProperty struct {


### PR DESCRIPTION
When we output the schema for a column from the PlanetScale source, we convert all `tinyint(1)` as a booleans. 
This behavior is  expected from Airbyte sources as confirmed here : https://github.com/airbytehq/airbyte/issues/10976#issuecomment-1175349214

But we do need to give customers the ability to opt out of this behavior. 
This PR allows customers to skip the default of `treating tinyint(1) as boolean` 

![image](https://user-images.githubusercontent.com/82819/181086564-c07be5cf-735c-4075-a83f-df258554427a.png)
