### PR TITLE
Do not serialize airbyte_secret value if its false

### DIFF
--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -211,10 +211,10 @@ type ConnectionProperty struct {
 	Title       string      `json:"title"`
 	Type        string      `json:"type"`
 	Order       int         `json:"order"`
-	IsSecret    bool        `json:"airbyte_secret"`
-	Minimum     int         `json:"minimum"`
-	Maximum     int         `json:"maximum"`
-	Default     interface{} `json:"default"`
+	IsSecret    bool        `json:"airbyte_secret,omitempty"`
+	Minimum     int         `json:"minimum,omitempty"`
+	Maximum     int         `json:"maximum,omitempty"`
+	Default     interface{} `json:"default,omitempty"`
 }
 
 type ConnectionSpecification struct {


### PR DESCRIPTION
Airbyte turns booleans into strings if the `airbyte_secret` value is available in the connector spec, regardless of it being true or false. This PR omits the `airbyte_secret` property in the serialized JSON if its not set.