### PR TITLE
Convert mysql decimal, double to JSONSchema number

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -108,6 +108,14 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool) PropertyTyp
 		return PropertyType{Type: "integer"}
 	}
 
+	if strings.HasPrefix(mysqlType, "decimal") {
+		return PropertyType{Type: "number"}
+	}
+
+	if strings.HasPrefix(mysqlType, "double") {
+		return PropertyType{Type: "number"}
+	}
+
 	if strings.HasPrefix(mysqlType, "bigint") {
 		return PropertyType{Type: "string", AirbyteType: "big_integer"}
 	}

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -108,11 +108,7 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool) PropertyTyp
 		return PropertyType{Type: "integer"}
 	}
 
-	if strings.HasPrefix(mysqlType, "decimal") {
-		return PropertyType{Type: "number"}
-	}
-
-	if strings.HasPrefix(mysqlType, "double") {
+	if strings.HasPrefix(mysqlType, "decimal") || strings.HasPrefix(mysqlType, "double") {
 		return PropertyType{Type: "number"}
 	}
 

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -210,6 +210,16 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 			JSONSchemaType: "string",
 			AirbyteType:    "",
 		},
+		{
+			MysqlType:      "decimal(12,5)",
+			JSONSchemaType: "number",
+			AirbyteType:    "",
+		},
+		{
+			MysqlType:      "double",
+			JSONSchemaType: "number",
+			AirbyteType:    "",
+		},
 	}
 
 	for _, typeTest := range tests {


### PR DESCRIPTION
We were annotating Decimal and Double fields as strings in the discovery output. This PR should use the right JsonSchema type for the mysql types of `decimal` and `double`

closes https://github.com/planetscale/airbyte-source/issues/49