### PR TITLE
introduce the format property for date-time fields

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -113,7 +113,7 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool) PropertyTyp
 	}
 
 	if strings.HasPrefix(mysqlType, "datetime") {
-		return PropertyType{Type: "string", AirbyteType: "timestamp_with_timezone"}
+		return PropertyType{Type: "string", CustomFormat: "date-time", AirbyteType: "timestamp_with_timezone"}
 	}
 
 	if mysqlType == "tinyint(1)" {

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -48,8 +48,9 @@ const (
 )
 
 type PropertyType struct {
-	Type        string `json:"type"`
-	AirbyteType string `json:"airbyte_type,omitempty"`
+	Type         string `json:"type"`
+	CustomFormat string `json:"format,omitempty"`
+	AirbyteType  string `json:"airbyte_type,omitempty"`
 }
 
 type StreamSchema struct {


### PR DESCRIPTION
From the docs at https://docs.airbyte.com/understanding-airbyte/supported-data-types/#the-types
We weren't outputting the `format` JSON Schema property in the JSONSchema

Airbyte type | JSON Schema | Examples
-- | -- | --
Datetime with timezone | {"type": "string", "format": "date-time", "airbyte_type": "timestamp_with_timezone"} | "2022-11-22T01:23:45+05:00"

Closes https://github.com/planetscale/airbyte-source/issues/50