### PR TITLE
Ensure that hostname is an Edge host when checking connection status

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -41,13 +41,13 @@ type PlanetScaleEdgeDatabase struct {
 
 func (p PlanetScaleEdgeDatabase) CanConnect(ctx context.Context, psc PlanetScaleSource) error {
 	if err := p.isEdgePassword(ctx, psc); err != nil {
-		return errors.New("Unable to reach connect enabled query endpoint for PlanetScale. Please ensure that your organization is enrolled in the Connect beta.")
+		return errors.New("This password will not function with PlanetScale Connect. Please ensure that your organization is enrolled in the Connect beta. ")
 	}
 
 	return p.Mysql.PingContext(ctx, psc)
 }
 
-func (p PlanetScaleEdgeDatabase) isEdgePassword(ctx context.Context, psc PlanetScaleSource) error {
+func (p PlanetScaleEdgeDatabase) checkEdgePassword(ctx context.Context, psc PlanetScaleSource) error {
 	reqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fmt.Sprintf("https://%v", psc.Host), nil)

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -40,7 +40,7 @@ type PlanetScaleEdgeDatabase struct {
 }
 
 func (p PlanetScaleEdgeDatabase) CanConnect(ctx context.Context, psc PlanetScaleSource) error {
-	if err := p.isEdgePassword(ctx, psc); err != nil {
+	if err := p.checkEdgePassword(ctx, psc); err != nil {
 		return errors.New("This password will not function with PlanetScale Connect. Please ensure that your organization is enrolled in the Connect beta. ")
 	}
 


### PR DESCRIPTION
We're seeing issues where our customers try to reuse legacy DBSS passwords when trying out Connect. 
To make this an easier onramp for them, we will try to reach out to Edge at port 443 and fail the connection check if the response isn't a Http error. 

``` bash
go build -o connect && ./connect check --config fails.json | jq .
{
  "type": "CONNECTION_STATUS",
  "connectionStatus": {
    "status": "FAILED",
    "message": "Unable to connect to PlanetScale database beam at host 9d75kyqlbspf.us-east-1.psdb.cloud with username 91goxtab8bvp0v8z08x0. Failed with \n Unable to reach connect enabled query endpoint for PlanetScale. Please ensure that your organization is enrolled in the Connect beta."
  }
}
```

Where the user sees this error message in Airbyte : 
```
Unable to connect to PlanetScale database beam at host 9d75kyqlbspf.us-east-1.psdb.cloud with username 91goxtab8bvp0v8z08x0. Failed with
 Unable to reach connect enabled query endpoint for PlanetScale. Please ensure that your organization is enrolled in the Connect beta.