### PR TITLE
Set AIRBYTE_ENTRYPOINT for docker images generated by goreleaser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ RUN apt-get update && apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /connect /usr/local/bin/
+ENV AIRBYTE_ENTRYPOINT "/usr/local/bin/connect"
 ENTRYPOINT ["/usr/local/bin/connect"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18rc1
+ARG GO_VERSION=1.19.2
 FROM golang:${GO_VERSION}-bullseye AS build
 
 WORKDIR /airbyte-source

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18rc1
+ARG GO_VERSION=1.19.2
 FROM golang:${GO_VERSION}-bullseye AS build
 
 RUN apt-get update && apt-get upgrade -y && \

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -6,4 +6,5 @@ RUN apt-get update && apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/*
 
 COPY connect /usr/local/bin/
+ENV AIRBYTE_ENTRYPOINT "/usr/local/bin/connect"
 ENTRYPOINT ["/usr/local/bin/connect"]

--- a/cmd/airbyte-source/check_test.go
+++ b/cmd/airbyte-source/check_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -20,9 +19,7 @@ func TestCheckFailsWithoutConfig(t *testing.T) {
 	b := bytes.NewBufferString("")
 	checkCommand.SetOut(b)
 	checkCommand.Execute()
-	out, err := ioutil.ReadAll(b)
-	assert.NoError(t, err)
-	assert.Equal(t, "Please provide path to a valid configuration file\n", string(out))
+	assert.Equal(t, "Please provide path to a valid configuration file\n", b.String())
 }
 
 func TestCheckInvalidCatalogJSON(t *testing.T) {
@@ -35,15 +32,13 @@ func TestCheckInvalidCatalogJSON(t *testing.T) {
 		Logger:     internal.NewLogger(os.Stdout),
 	})
 	b := bytes.NewBufferString("")
-
 	checkCommand.SetArgs([]string{"config source.json"})
 	checkCommand.SetOut(b)
 	checkCommand.Flag("config").Value.Set("catalog.json")
 	checkCommand.Execute()
-	out, err := ioutil.ReadAll(b)
-	assert.NoError(t, err)
+
 	var amsg internal.AirbyteMessage
-	err = json.Unmarshal(out, &amsg)
+	err := json.NewDecoder(b).Decode(&amsg)
 	assert.NoError(t, err)
 	assert.Equal(t, internal.CONNECTION_STATUS, amsg.Type)
 	require.NotNil(t, amsg.ConnectionStatus)
@@ -70,10 +65,9 @@ func TestCheckCredentialsInvalid(t *testing.T) {
 	checkCommand.SetOut(b)
 	checkCommand.Flag("config").Value.Set("catalog.json")
 	checkCommand.Execute()
-	out, err := ioutil.ReadAll(b)
-	assert.NoError(t, err)
+
 	var amsg internal.AirbyteMessage
-	err = json.Unmarshal(out, &amsg)
+	err := json.NewDecoder(b).Decode(&amsg)
 	require.NoError(t, err)
 	assert.Equal(t, internal.CONNECTION_STATUS, amsg.Type)
 	assert.NotNil(t, amsg.ConnectionStatus)
@@ -102,10 +96,9 @@ func TestCheckExecuteSuccessful(t *testing.T) {
 
 	checkCommand.Flag("config").Value.Set("catalog.json")
 	checkCommand.Execute()
-	out, err := ioutil.ReadAll(b)
-	assert.NoError(t, err)
+
 	var amsg internal.AirbyteMessage
-	err = json.Unmarshal(out, &amsg)
+	err := json.NewDecoder(b).Decode(&amsg)
 	require.NoError(t, err)
 	assert.Equal(t, internal.CONNECTION_STATUS, amsg.Type)
 	assert.NotNil(t, amsg.ConnectionStatus)

--- a/cmd/airbyte-source/discover_test.go
+++ b/cmd/airbyte-source/discover_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"testing"
 
 	"github.com/planetscale/airbyte-source/cmd/internal"
@@ -33,10 +32,9 @@ func TestDiscoverInvalidSource(t *testing.T) {
 	discover.SetOut(b)
 	discover.Flag("config").Value.Set("catalog.json")
 	discover.Execute()
-	out, err := ioutil.ReadAll(b)
-	assert.NoError(t, err)
+
 	var amsg internal.AirbyteMessage
-	err = json.Unmarshal(out, &amsg)
+	err := json.NewDecoder(b).Decode(&amsg)
 	require.NoError(t, err)
 	assert.Equal(t, internal.CONNECTION_STATUS, amsg.Type)
 	assert.NotNil(t, amsg.ConnectionStatus)
@@ -67,10 +65,8 @@ func TestDiscoverFailed(t *testing.T) {
 	discover.SetOut(b)
 	discover.Flag("config").Value.Set("catalog.json")
 	discover.Execute()
-	out, err := ioutil.ReadAll(b)
-	assert.NoError(t, err)
 	var amsg internal.AirbyteMessage
-	err = json.Unmarshal(out, &amsg)
+	err := json.NewDecoder(b).Decode(&amsg)
 	require.NoError(t, err)
 	assert.Equal(t, internal.LOG, amsg.Type)
 	require.NotNil(t, amsg.Log)

--- a/cmd/airbyte-source/helper.go
+++ b/cmd/airbyte-source/helper.go
@@ -1,10 +1,9 @@
 package airbyte_source
 
 import (
-	"io"
-	"io/ioutil"
-
 	"github.com/planetscale/airbyte-source/cmd/internal"
+	"io"
+	"os"
 )
 
 type Helper struct {
@@ -20,7 +19,7 @@ type FileReader interface {
 type fileReader struct{}
 
 func (f fileReader) ReadFile(path string) ([]byte, error) {
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func DefaultHelper(w io.Writer) *Helper {

--- a/cmd/airbyte-source/read.go
+++ b/cmd/airbyte-source/read.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/planetscale/airbyte-source/cmd/internal"
@@ -75,7 +74,7 @@ func ReadCommand(ch *Helper) *cobra.Command {
 
 			state := ""
 			if stateFilePath != "" {
-				b, err := ioutil.ReadFile(stateFilePath)
+				b, err := os.ReadFile(stateFilePath)
 				if err != nil {
 					ch.Logger.Error(fmt.Sprintf("Unable to read state : %v", err))
 					os.Exit(1)
@@ -173,7 +172,7 @@ func readState(state string, psc internal.PlanetScaleSource, streams []internal.
 }
 
 func readCatalog(path string) (c internal.ConfiguredCatalog, err error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return c, err
 	}

--- a/cmd/airbyte-source/spec_test.go
+++ b/cmd/airbyte-source/spec_test.go
@@ -3,7 +3,6 @@ package airbyte_source
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"testing"
 
 	"github.com/planetscale/airbyte-source/cmd/internal"
@@ -15,10 +14,8 @@ func TestSpecExecute(t *testing.T) {
 	b := bytes.NewBufferString("")
 	specCommand.SetOut(b)
 	specCommand.Execute()
-	out, err := ioutil.ReadAll(b)
-	assert.NoError(t, err)
 	var specMessage internal.SpecMessage
-	err = json.Unmarshal(out, &specMessage)
+	err := json.NewDecoder(b).Decode(&specMessage)
 	assert.Nil(t, err, "should unmarshal spec JSON")
 	assert.Equal(t, "SPEC", specMessage.Type)
 	assert.NotNil(t, specMessage.Spec)

--- a/cmd/e2e/e2e_test.go
+++ b/cmd/e2e/e2e_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,10 +24,8 @@ func TestCheck(t *testing.T) {
 	b := bytes.NewBufferString("")
 	checkCommand.SetOut(b)
 	checkCommand.Execute()
-	out, err := ioutil.ReadAll(b)
-	assert.NoError(t, err)
 	var msg internal.AirbyteMessage
-	err = json.Unmarshal(out, &msg)
+	err := json.NewDecoder(b).Decode(&msg)
 	assert.NoError(t, err)
 	assert.Equal(t, internal.CONNECTION_STATUS, msg.Type)
 	require.NotNil(t, msg.ConnectionStatus)
@@ -46,16 +43,14 @@ func TestDiscover(t *testing.T) {
 	b := bytes.NewBufferString("")
 	discover.SetOut(b)
 	discover.Execute()
-	out, err := ioutil.ReadAll(b)
-	assert.NoError(t, err)
 	var msg internal.AirbyteMessage
-	err = json.Unmarshal(out, &msg)
+	err := json.NewDecoder(b).Decode(&msg)
 	assert.NoError(t, err)
 	assert.Equal(t, internal.CATALOG, msg.Type)
 	require.NotNil(t, msg.Catalog)
 	s, err := json.Marshal(msg.Catalog)
 	assert.NoError(t, err)
-	fullCatalog, err := ioutil.ReadFile("../../fixture/sakila-db/full_catalog.json")
+	fullCatalog, err := os.ReadFile("../../fixture/sakila-db/full_catalog.json")
 	assert.NoError(t, err)
 	assert.Equal(t, string(fullCatalog), string(s))
 }

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
+	github.com/pires/go-proxyproto v0.6.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -860,6 +860,8 @@ github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pires/go-proxyproto v0.0.0-20191211124218-517ecdf5bb2b h1:JPLdtNmpXbWytipbGwYz7zXZzlQNASEiFw5aGAM75us=
 github.com/pires/go-proxyproto v0.0.0-20191211124218-517ecdf5bb2b/go.mod h1:Odh9VFOZJCf9G8cLW5o435Xf1J95Jw9Gw5rnCjcwzAY=
+github.com/pires/go-proxyproto v0.6.2 h1:KAZ7UteSOt6urjme6ZldyFm4wDe/z0ZUP0Yv0Dos0d8=
+github.com/pires/go-proxyproto v0.6.2/go.mod h1:Odh9VFOZJCf9G8cLW5o435Xf1J95Jw9Gw5rnCjcwzAY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
https://airbyte.com/blog/extending-docker-images-on-kubernetes
This seems to be necessary for running our airbyte source in Kubernetes