### PR TITLE
Show distinct error message for edge unavailability

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -60,7 +60,7 @@ func (p PlanetScaleEdgeDatabase) checkEdgePassword(ctx context.Context, psc Plan
 
 	_, err = http.DefaultClient.Do(req)
 	if err != nil {
-		errors.New(fmt.Sprintf("The database %q, hosted at %q, is inaccessible from this process", psc.Database, psc.Host))
+		return errors.New(fmt.Sprintf("The database %q, hosted at %q, is inaccessible from this process", psc.Database, psc.Host))
 	}
 
 	return nil

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -41,13 +41,16 @@ type PlanetScaleEdgeDatabase struct {
 
 func (p PlanetScaleEdgeDatabase) CanConnect(ctx context.Context, psc PlanetScaleSource) error {
 	if err := p.checkEdgePassword(ctx, psc); err != nil {
-		return errors.New("This password will not function with PlanetScale Connect. Please ensure that your organization is enrolled in the Connect beta. ")
+		return errors.Wrap(err, "Unable to initialize Connect Session")
 	}
 
 	return p.Mysql.PingContext(ctx, psc)
 }
 
 func (p PlanetScaleEdgeDatabase) checkEdgePassword(ctx context.Context, psc PlanetScaleSource) error {
+	if !strings.HasSuffix(psc.Host, ".connect.psdb.cloud") {
+		return errors.New("This password is not connect-enabled, please ensure that your organization is enrolled in the Connect beta.")
+	}
 	reqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fmt.Sprintf("https://%v", psc.Host), nil)
@@ -56,7 +59,11 @@ func (p PlanetScaleEdgeDatabase) checkEdgePassword(ctx context.Context, psc Plan
 	}
 
 	_, err = http.DefaultClient.Do(req)
-	return err
+	if err != nil {
+		errors.New(fmt.Sprintf("The database %q, hosted at %q, is inaccessible from this process", psc.Database, psc.Host))
+	}
+
+	return nil
 }
 
 func (p PlanetScaleEdgeDatabase) DiscoverSchema(ctx context.Context, psc PlanetScaleSource) (Catalog, error) {


### PR DESCRIPTION
This PR fixes the error messages we show when a password is not connect-enabled or the edge host is unavailable for a given airbyte process.


### Examples
1. Password is not connect-enabled: 
``` json
{
  "type": "CONNECTION_STATUS",
  "connectionStatus": {
    "status": "FAILED",
    "message": "Unable to connect to PlanetScale database import-on-scaler at host us-east.connector.psdb.cloud with username le9acunm77jmqj81otd3. Failed with \n Unable to initialize Connect Session: This password is not connect-enabled, please ensure that your organization is enrolled in the Connect beta."
  }
}
```

2. Password is connect-enabled, host is inaccessible.

``` json
{
  "type": "CONNECTION_STATUS",
  "connectionStatus": {
    "status": "FAILED",
    "message": "Unable to connect to PlanetScale database import-on-scaler at host 6445ej5qyrif-useast1.connect.psdb.cloud with username le9acunm77jmqj81otd3. Failed with \n Unable to initialize Connect Session: The database \"import-on-scaler\", hosted at \"6445ej5qyrif-useast1.connect.psdb.cloud\", is inaccessible from this process"
  }
}
```