### PR TITLE
Do not output timestamp_with_timezone Airbyte type for datetime columns

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -141,7 +141,7 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool) PropertyTyp
 	}
 
 	if strings.HasPrefix(mysqlType, "datetime") {
-		return PropertyType{Type: "string", CustomFormat: "date-time", AirbyteType: "timestamp_with_timezone"}
+		return PropertyType{Type: "string", CustomFormat: "date-time", AirbyteType: "timestamp_without_timezone"}
 	}
 
 	if mysqlType == "tinyint(1)" {
@@ -156,7 +156,7 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool) PropertyTyp
 	case "date":
 		return PropertyType{Type: "string", AirbyteType: "date"}
 	case "datetime":
-		return PropertyType{Type: "string", AirbyteType: "timestamp_with_timezone"}
+		return PropertyType{Type: "string", AirbyteType: "timestamp_without_timezone"}
 	default:
 		return PropertyType{Type: "string"}
 	}

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -193,7 +193,7 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 		{
 			MysqlType:      "datetime",
 			JSONSchemaType: "string",
-			AirbyteType:    "timestamp_with_timezone",
+			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "date",


### PR DESCRIPTION
Fixes #55

Since we don't output the timezone information when serializing a `timestamp_with_timezone`, we see errors such as these in airbyte console : 
``` bash
2022-11-01 09:36:05 [1;31mERROR[m c.n.s.DateTimeValidator(tryParse):82 -
  Invalid date-time: No timezone information: 2022-10-24 12:01:11.000
```

Mysql does not store timezone information, do not output timestamp_with_timezone for datetime(3)