### PR TITLE
Use cell alias for all cells in a vitess cluster instead of querying vitess

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"strings"
 	"time"
 
@@ -171,25 +170,6 @@ func (p PlanetScaleEdgeDatabase) ListShards(ctx context.Context, psc PlanetScale
 	return p.Mysql.GetVitessShards(ctx, psc)
 }
 
-func (p PlanetScaleEdgeDatabase) ListCells(ctx context.Context, psc PlanetScaleSource) ([]string, error) {
-	var cells []string
-	tablets, err := p.Mysql.GetVitessTablets(ctx, psc)
-
-	if err != nil {
-		return cells, err
-	}
-
-	for _, vttablet := range tablets {
-		if strings.EqualFold(vttablet.Keyspace, psc.Database) {
-			if !slices.Contains(cells, vttablet.Cell) {
-				cells = append(cells, vttablet.Cell)
-			}
-		}
-	}
-
-	return cells, nil
-}
-
 // Read streams rows from a table given a starting cursor.
 // 1. We will get the latest vgtid for a given table in a shard when a sync session starts.
 // 2. This latest vgtid is now the stopping point for this sync session.
@@ -208,12 +188,7 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, w io.Writer, ps Plane
 		tabletType = psdbconnect.TabletType_replica
 	}
 
-	cells, err := p.ListCells(ctx, ps)
-	if err != nil {
-		return currentSerializedCursor, err
-	}
-
-	p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("Syncing from tabletType \"%v\", from cells: %v", TabletTypeToString(tabletType), cells))
+	p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("Syncing from tabletType \"%v\"", TabletTypeToString(tabletType)))
 
 	currentPosition := lastKnownPosition
 	table := s.Stream
@@ -221,7 +196,7 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, w io.Writer, ps Plane
 	preamble := fmt.Sprintf("[%v:%v:%v shard : %v] ", table.Namespace, TabletTypeToString(tabletType), table.Name, currentPosition.Shard)
 	for {
 		p.Logger.Log(LOGLEVEL_INFO, preamble+"peeking to see if there's any new rows")
-		latestCursorPosition, lcErr := p.getLatestCursorPosition(ctx, currentPosition.Shard, currentPosition.Keyspace, table, ps, tabletType, cells)
+		latestCursorPosition, lcErr := p.getLatestCursorPosition(ctx, currentPosition.Shard, currentPosition.Keyspace, table, ps, tabletType)
 		if lcErr != nil {
 			return currentSerializedCursor, errors.Wrap(err, "Unable to get latest cursor position")
 		}
@@ -234,7 +209,7 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, w io.Writer, ps Plane
 		p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("new rows found, syncing rows for %v", readDuration))
 		p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf(preamble+"syncing rows with cursor [%v]", currentPosition))
 
-		currentPosition, err = p.sync(ctx, currentPosition, latestCursorPosition, table, ps, tabletType, cells, readDuration)
+		currentPosition, err = p.sync(ctx, currentPosition, latestCursorPosition, table, ps, tabletType, readDuration)
 		if currentPosition.Position != "" {
 			currentSerializedCursor, sErr = TableCursorToSerializedCursor(currentPosition)
 			if sErr != nil {
@@ -262,7 +237,7 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, w io.Writer, ps Plane
 	}
 }
 
-func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.TableCursor, stopPosition string, s Stream, ps PlanetScaleSource, tabletType psdbconnect.TabletType, cells []string, readDuration time.Duration) (*psdbconnect.TableCursor, error) {
+func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.TableCursor, stopPosition string, s Stream, ps PlanetScaleSource, tabletType psdbconnect.TabletType, readDuration time.Duration) (*psdbconnect.TableCursor, error) {
 	defer p.Logger.Flush()
 	ctx, cancel := context.WithTimeout(ctx, readDuration)
 	defer cancel()
@@ -303,7 +278,7 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 		TableName:  s.Name,
 		Cursor:     tc,
 		TabletType: tabletType,
-		Cells:      cells,
+		Cells:      []string{"planetscale_operator_default"},
 	}
 	p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("DEBUG: SyncRequest.Cells = %v", sReq.GetCells()))
 
@@ -358,7 +333,7 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 	}
 }
 
-func (p PlanetScaleEdgeDatabase) getLatestCursorPosition(ctx context.Context, shard, keyspace string, s Stream, ps PlanetScaleSource, tabletType psdbconnect.TabletType, cells []string) (string, error) {
+func (p PlanetScaleEdgeDatabase) getLatestCursorPosition(ctx context.Context, shard, keyspace string, s Stream, ps PlanetScaleSource, tabletType psdbconnect.TabletType) (string, error) {
 	defer p.Logger.Flush()
 	timeout := 45 * time.Second
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -397,7 +372,7 @@ func (p PlanetScaleEdgeDatabase) getLatestCursorPosition(ctx context.Context, sh
 			Position: "current",
 		},
 		TabletType: tabletType,
-		Cells:      cells,
+		Cells:      []string{"planetscale_operator_default"},
 	}
 
 	c, err := client.Sync(ctx, sReq)

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -59,7 +59,7 @@ func TestRead_CanPeekBeforeRead(t *testing.T) {
 	assert.Equal(t, esc, sc)
 	assert.Equal(t, 1, cc.syncFnInvokedCount)
 	assert.False(t, tma.PingContextFnInvoked)
-	assert.True(t, tma.GetVitessTabletsFnInvoked)
+	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
 
 func TestRead_CanEarlyExitIfNoNewVGtidInPeek(t *testing.T) {
@@ -126,7 +126,7 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
 			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
-			assert.Contains(t, in.Cells, "test_cell_primary")
+			assert.Contains(t, in.Cells, "planetscale_operator_default")
 			return syncClient, nil
 		},
 	}
@@ -149,7 +149,7 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 	assert.Equal(t, esc, sc)
 	assert.Equal(t, 1, cc.syncFnInvokedCount)
 	assert.False(t, tma.PingContextFnInvoked)
-	assert.True(t, tma.GetVitessTabletsFnInvoked)
+	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
 
 func TestRead_CanPickReplicaForShardedKeyspaces(t *testing.T) {
@@ -174,7 +174,7 @@ func TestRead_CanPickReplicaForShardedKeyspaces(t *testing.T) {
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
 			assert.Equal(t, psdbconnect.TabletType_replica, in.TabletType)
-			assert.Contains(t, in.Cells, "test_cell_replica")
+			assert.Contains(t, in.Cells, "planetscale_operator_default")
 			return syncClient, nil
 		},
 	}
@@ -198,7 +198,7 @@ func TestRead_CanPickReplicaForShardedKeyspaces(t *testing.T) {
 	assert.Equal(t, esc, sc)
 	assert.Equal(t, 1, cc.syncFnInvokedCount)
 	assert.False(t, tma.PingContextFnInvoked)
-	assert.True(t, tma.GetVitessTabletsFnInvoked)
+	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
 
 func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
@@ -305,7 +305,7 @@ func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
 			assert.Equal(t, psdbconnect.TabletType_primary, in.TabletType)
-			assert.Contains(t, in.Cells, "test_cell_primary")
+			assert.Contains(t, in.Cells, "planetscale_operator_default")
 			return syncClient, nil
 		},
 	}
@@ -328,7 +328,7 @@ func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 	assert.Equal(t, esc, sc)
 	assert.Equal(t, 1, cc.syncFnInvokedCount)
 	assert.False(t, tma.PingContextFnInvoked)
-	assert.True(t, tma.GetVitessTabletsFnInvoked)
+	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
 
 func TestRead_CanPickReplicaForUnshardedKeyspaces(t *testing.T) {
@@ -355,7 +355,7 @@ func TestRead_CanPickReplicaForUnshardedKeyspaces(t *testing.T) {
 	cc := clientConnectionMock{
 		syncFn: func(ctx context.Context, in *psdbconnect.SyncRequest, opts ...grpc.CallOption) (psdbconnect.Connect_SyncClient, error) {
 			assert.Equal(t, psdbconnect.TabletType_replica, in.TabletType)
-			assert.Contains(t, in.Cells, "test_cell_replica")
+			assert.Contains(t, in.Cells, "planetscale_operator_default")
 			return syncClient, nil
 		},
 	}
@@ -379,7 +379,7 @@ func TestRead_CanPickReplicaForUnshardedKeyspaces(t *testing.T) {
 	assert.Equal(t, esc, sc)
 	assert.Equal(t, 1, cc.syncFnInvokedCount)
 	assert.False(t, tma.PingContextFnInvoked)
-	assert.True(t, tma.GetVitessTabletsFnInvoked)
+	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
 
 func TestRead_CanReturnOriginalCursorIfNoNewFound(t *testing.T) {


### PR DESCRIPTION
PlanetScale databases have a cell alias that is universal across the vitess clusters we create, we can use this instead of querying for the vitess tablets.

``` bash 
GetCellsAliases
```

``` json
{
  "planetscale_operator_default": {
    "cells": [
      "aws_useast2a_2",
      "aws_useast2b_2",
      "aws_useast2c_2"
    ]
  }
}
```