### PR TITLE
Support `tinyint(1) unsigned` for `boolean` conversion

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -138,7 +138,7 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool) PropertyTyp
 	}
 
 	if strings.HasPrefix(mysqlType, "bigint") {
-		return PropertyType{Type: "integer", AirbyteType: "big_integer"}
+		return PropertyType{Type: "string", AirbyteType: "big_integer"}
 	}
 
 	if strings.HasPrefix(mysqlType, "datetime") {

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
-	"github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	"github.com/planetscale/psdb/auth"

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	
 	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	"github.com/planetscale/psdb/auth"

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
-	
+
 	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	"github.com/planetscale/psdb/auth"

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	"github.com/planetscale/psdb/auth"
@@ -137,14 +138,14 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool) PropertyTyp
 	}
 
 	if strings.HasPrefix(mysqlType, "bigint") {
-		return PropertyType{Type: "string", AirbyteType: "big_integer"}
+		return PropertyType{Type: "integer", AirbyteType: "big_integer"}
 	}
 
 	if strings.HasPrefix(mysqlType, "datetime") {
 		return PropertyType{Type: "string", CustomFormat: "date-time", AirbyteType: "timestamp_without_timezone"}
 	}
 
-	if mysqlType == "tinyint(1)" {
+	if strings.HasPrefix(mysqlType, "tinyint(1)") {
 		if treatTinyIntAsBoolean {
 			return PropertyType{Type: "boolean"}
 		}

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -220,24 +220,36 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 			TreatTinyIntAsBoolean: true,
 		},
 		{
+			MysqlType:             "tinyint(1) unsigned",
+			JSONSchemaType:        "boolean",
+			AirbyteType:           "",
+			TreatTinyIntAsBoolean: true,
+		},
+		{
 			MysqlType:             "tinyint(1)",
 			JSONSchemaType:        "integer",
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
+			MysqlType:             "tinyint(1) unsigned",
+			JSONSchemaType:        "integer",
+			AirbyteType:           "",
+			TreatTinyIntAsBoolean: false,
+		},
+		{
 			MysqlType:      "bigint(16)",
-			JSONSchemaType: "string",
+			JSONSchemaType: "integer",
 			AirbyteType:    "big_integer",
 		},
 		{
 			MysqlType:      "bigint unsigned",
-			JSONSchemaType: "string",
+			JSONSchemaType: "integer",
 			AirbyteType:    "big_integer",
 		},
 		{
 			MysqlType:      "bigint zerofill",
-			JSONSchemaType: "string",
+			JSONSchemaType: "integer",
 			AirbyteType:    "big_integer",
 		},
 		{

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -239,17 +239,17 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 		},
 		{
 			MysqlType:      "bigint(16)",
-			JSONSchemaType: "integer",
+			JSONSchemaType: "string",
 			AirbyteType:    "big_integer",
 		},
 		{
 			MysqlType:      "bigint unsigned",
-			JSONSchemaType: "integer",
+			JSONSchemaType: "string",
 			AirbyteType:    "big_integer",
 		},
 		{
 			MysqlType:      "bigint zerofill",
-			JSONSchemaType: "integer",
+			JSONSchemaType: "string",
 			AirbyteType:    "big_integer",
 		},
 		{


### PR DESCRIPTION
Partial fix for #83 