### PR TITLE
fix tinyint schema detection

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -134,7 +134,7 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool) PropertyTyp
 			return PropertyType{Type: "boolean"}
 		}
 		return PropertyType{Type: "number", AirbyteType: "integer"}
-	case strings.HasPrefix(mysqlType, "int"), strings.HasPrefix(mysqlType, "smallint"), strings.HasPrefix(mysqlType, "mediumint"), strings.HasPrefix(mysqlType, "bigint"):
+	case strings.HasPrefix(mysqlType, "int"), strings.HasPrefix(mysqlType, "smallint"), strings.HasPrefix(mysqlType, "mediumint"), strings.HasPrefix(mysqlType, "bigint"), strings.HasPrefix(mysqlType, "tinyint"):
 		return PropertyType{Type: "number", AirbyteType: "integer"}
 	case strings.HasPrefix(mysqlType, "decimal"), strings.HasPrefix(mysqlType, "double"), strings.HasPrefix(mysqlType, "float"):
 		return PropertyType{Type: "number"}

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -225,6 +225,12 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 			AirbyteType:    "integer",
 		},
 		{
+			MysqlType:             "tinyint",
+			JSONSchemaType:        "number",
+			AirbyteType:           "integer",
+			TreatTinyIntAsBoolean: true,
+		},
+		{
 			MysqlType:             "tinyint(1)",
 			JSONSchemaType:        "boolean",
 			AirbyteType:           "",


### PR DESCRIPTION
We're detecting a tinyint as a string column and even though we serialize an integer, the airbyte destination can turn the integer into a string. 

Resolves https://github.com/planetscale/airbyte-source/issues/89