### PR TITLE
Fix enum & set values after COPY phase

### DIFF
--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -2,11 +2,12 @@ package internal
 
 import (
 	"encoding/base64"
+	"testing"
+
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	"github.com/planetscale/psdb/core/codec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/proto/query"
 )
@@ -75,4 +76,35 @@ func TestCanUnmarshalLastKnownState(t *testing.T) {
 	assert.Equal(t, "40-80", tc.Shard)
 	assert.Equal(t, "THIS_IS_A_GTID", tc.Position)
 	assert.Equal(t, lastKnownPK, tc.LastKnownPk)
+}
+
+func TestCanMapEnumAndSetValues(t *testing.T) {
+	indexEnumValue, err := sqltypes.NewValue(query.Type_ENUM, []byte("1"))
+	assert.NoError(t, err)
+	indexSetValue, err := sqltypes.NewValue(query.Type_SET, []byte("24")) // 24 is decimal conversion of 11000 in binary
+	assert.NoError(t, err)
+	mappedEnumValue, err := sqltypes.NewValue(query.Type_ENUM, []byte("active"))
+	assert.NoError(t, err)
+	mappedSetValue, err := sqltypes.NewValue(query.Type_SET, []byte("San Francisco,Oakland"))
+	assert.NoError(t, err)
+	input := sqltypes.Result{
+		Fields: []*query.Field{
+			{Name: "customer_id", Type: sqltypes.Int64, ColumnType: "bigint"},
+			{Name: "status", Type: sqltypes.Enum, ColumnType: "enum('active','inactive')"},
+			{Name: "locations", Type: sqltypes.Set, ColumnType: "set('San Francisco','New York','London','San Jose','Oakland')"},
+		},
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewInt64(1), indexEnumValue, indexSetValue},
+			{sqltypes.NewInt64(2), mappedEnumValue, mappedSetValue},
+		},
+	}
+
+	output := QueryResultToRecords(&input)
+	assert.Equal(t, 2, len(output))
+	firstRow := output[0]
+	assert.Equal(t, "active", firstRow["status"].(sqltypes.Value).ToString())
+	assert.Equal(t, "San Jose,Oakland", firstRow["locations"].(sqltypes.Value).ToString())
+	secondRow := output[1]
+	assert.Equal(t, "active", secondRow["status"].(sqltypes.Value).ToString())
+	assert.Equal(t, "San Francisco,Oakland", secondRow["locations"].(sqltypes.Value).ToString())
 }


### PR DESCRIPTION
This PR addresses https://github.com/planetscale/airbyte-source/issues/56 and adds extra support for mapping `ENUM` and `SET` values after the initial COPY phase of replication. 

During the replicating phase, we expect enum and set values to appear as their indices (`"1"`) rather than their value (`"apple"` in a column of type `enum('apple','banana','orange')`). Because of this, we need extra logic to map them to their actual value before passing the value on to Airbyte.
