### PR TITLE
Change spec format

### DIFF
--- a/cmd/airbyte-source/spec.json
+++ b/cmd/airbyte-source/spec.json
@@ -1,91 +1,85 @@
 {
-  "type": "SPEC",
-  "spec": {
-    "documentationUrl": "https://planetscale.com/docs/integrations/airbyte",
-    "connectionSpecification": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "PlanetScale Source Spec",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PlanetScale Source Spec",
+  "type": "object",
+  "required": [
+    "host",
+    "database",
+    "username",
+    "password"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "host": {
+      "description": "The host name of the database.",
+      "title": "Host",
+      "type": "string",
+      "order": 0
+    },
+    "shards": {
+      "description": "Comma separated list of shards you'd like to sync, by default all shards are synced.",
+      "title": "Shards",
+      "type": "string",
+      "order": 5
+    },
+    "database": {
+      "description": "The PlanetScale database name.",
+      "title": "Database",
+      "type": "string",
+      "order": 1
+    },
+    "username": {
+      "description": "The username which is used to access the database.",
+      "title": "Username",
+      "type": "string",
+      "order": 2
+    },
+    "password": {
+      "description": "The password associated with the username.",
+      "title": "Password",
+      "type": "string",
+      "order": 3,
+      "airbyte_secret": true
+    },
+    "use_replica": {
+      "description": "Use a replica to pull data from",
+      "title": "Use replica?",
+      "type": "boolean",
+      "default": false,
+      "order": 4
+    },
+    "starting_gtids": {
+      "type": "string",
+      "title": "Starting GTIDs",
+      "default": "",
+      "description": "A JSON string containing start GTIDs for every { keyspace: { shard: starting_gtid } }",
+      "order": 6
+    },
+    "options": {
       "type": "object",
-      "required": [
-        "host",
-        "database",
-        "username",
-        "password"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "host": {
-          "description": "The host name of the database.",
-          "title": "Host",
-          "type": "string",
-          "order": 0
-        },
-        "shards": {
-          "description": "Comma separated list of shards you'd like to sync, by default all shards are synced.",
-          "title": "Shards",
-          "type": "string",
-          "order": 5
-        },
-        "database": {
-          "description": "The PlanetScale database name.",
-          "title": "Database",
-          "type": "string",
-          "order": 1
-        },
-        "username": {
-          "description": "The username which is used to access the database.",
-          "title": "Username",
-          "type": "string",
-          "order": 2
-        },
-        "password": {
-          "description": "The password associated with the username.",
-          "title": "Password",
-          "type": "string",
-          "order": 3,
-          "airbyte_secret": true
-        },
-        "use_replica": {
-          "description": "Use a replica to pull data from",
-          "title": "Use replica?",
-          "type": "boolean",
-          "default": false,
-          "order": 4
-        },
-        "starting_gtids": {
-          "type": "string",
-          "title": "Starting GTIDs",
-          "default": "",
-          "description": "A JSON string containing start GTIDs for every { keyspace: { shard: starting_gtid } }",
-          "order": 6
-        },
-        "options": {
-          "type": "object",
-          "title": "Customize serialization",
-          "description": "The storage Provider or Location of the file(s) which should be replicated.",
-          "default": "Public Web",
-          "oneOf": [
-            {
-              "title": "tinyint(1) serialization",
-              "required": [
-                "do_not_treat_tiny_int_as_boolean"
-              ],
-              "properties": {
-                "storage": {
-                  "type": "string",
-                  "const": "HTTPS"
-                },
-                "do_not_treat_tiny_int_as_boolean": {
-                  "type": "boolean",
-                  "title": "Do not treat tinyint(1) as boolean",
-                  "default": false,
-                  "description": "If enabled, properties of type TinyInt(1) are output as TinyInt, and not boolean."
-                }
-              }
+      "title": "Customize serialization",
+      "description": "The storage Provider or Location of the file(s) which should be replicated.",
+      "default": "Public Web",
+      "oneOf": [
+        {
+          "title": "tinyint(1) serialization",
+          "required": [
+            "do_not_treat_tiny_int_as_boolean"
+          ],
+          "properties": {
+            "storage": {
+              "type": "string",
+              "const": "HTTPS"
+            },
+            "do_not_treat_tiny_int_as_boolean": {
+              "type": "boolean",
+              "title": "Do not treat tinyint(1) as boolean",
+              "default": false,
+              "description": "If enabled, properties of type TinyInt(1) are output as TinyInt, and not boolean."
             }
-          ]
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/cmd/airbyte-source/spec.json
+++ b/cmd/airbyte-source/spec.json
@@ -1,85 +1,87 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "PlanetScale Source Spec",
-  "type": "object",
-  "required": [
-    "host",
-    "database",
-    "username",
-    "password"
-  ],
-  "additionalProperties": false,
-  "properties": {
-    "host": {
-      "description": "The host name of the database.",
-      "title": "Host",
-      "type": "string",
-      "order": 0
-    },
-    "shards": {
-      "description": "Comma separated list of shards you'd like to sync, by default all shards are synced.",
-      "title": "Shards",
-      "type": "string",
-      "order": 5
-    },
-    "database": {
-      "description": "The PlanetScale database name.",
-      "title": "Database",
-      "type": "string",
-      "order": 1
-    },
-    "username": {
-      "description": "The username which is used to access the database.",
-      "title": "Username",
-      "type": "string",
-      "order": 2
-    },
-    "password": {
-      "description": "The password associated with the username.",
-      "title": "Password",
-      "type": "string",
-      "order": 3,
-      "airbyte_secret": true
-    },
-    "use_replica": {
-      "description": "Use a replica to pull data from",
-      "title": "Use replica?",
-      "type": "boolean",
-      "default": false,
-      "order": 4
-    },
-    "starting_gtids": {
-      "type": "string",
-      "title": "Starting GTIDs",
-      "default": "",
-      "description": "A JSON string containing start GTIDs for every { keyspace: { shard: starting_gtid } }",
-      "order": 6
-    },
-    "options": {
-      "type": "object",
-      "title": "Customize serialization",
-      "description": "The storage Provider or Location of the file(s) which should be replicated.",
-      "default": "Public Web",
-      "oneOf": [
-        {
-          "title": "tinyint(1) serialization",
-          "required": [
-            "do_not_treat_tiny_int_as_boolean"
-          ],
-          "properties": {
-            "storage": {
-              "type": "string",
-              "const": "HTTPS"
-            },
-            "do_not_treat_tiny_int_as_boolean": {
-              "type": "boolean",
-              "title": "Do not treat tinyint(1) as boolean",
-              "default": false,
-              "description": "If enabled, properties of type TinyInt(1) are output as TinyInt, and not boolean."
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PlanetScale Source Spec",
+    "type": "object",
+    "required": [
+      "host",
+      "database",
+      "username",
+      "password"
+    ],
+    "additionalProperties": false,
+    "properties": {
+      "host": {
+        "description": "The host name of the database.",
+        "title": "Host",
+        "type": "string",
+        "order": 0
+      },
+      "shards": {
+        "description": "Comma separated list of shards you'd like to sync, by default all shards are synced.",
+        "title": "Shards",
+        "type": "string",
+        "order": 5
+      },
+      "database": {
+        "description": "The PlanetScale database name.",
+        "title": "Database",
+        "type": "string",
+        "order": 1
+      },
+      "username": {
+        "description": "The username which is used to access the database.",
+        "title": "Username",
+        "type": "string",
+        "order": 2
+      },
+      "password": {
+        "description": "The password associated with the username.",
+        "title": "Password",
+        "type": "string",
+        "order": 3,
+        "airbyte_secret": true
+      },
+      "use_replica": {
+        "description": "Use a replica to pull data from",
+        "title": "Use replica?",
+        "type": "boolean",
+        "default": false,
+        "order": 4
+      },
+      "starting_gtids": {
+        "type": "string",
+        "title": "Starting GTIDs",
+        "default": "",
+        "description": "A JSON string containing start GTIDs for every { keyspace: { shard: starting_gtid } }",
+        "order": 6
+      },
+      "options": {
+        "type": "object",
+        "title": "Customize serialization",
+        "description": "The storage Provider or Location of the file(s) which should be replicated.",
+        "default": "Public Web",
+        "oneOf": [
+          {
+            "title": "tinyint(1) serialization",
+            "required": [
+              "do_not_treat_tiny_int_as_boolean"
+            ],
+            "properties": {
+              "storage": {
+                "type": "string",
+                "const": "HTTPS"
+              },
+              "do_not_treat_tiny_int_as_boolean": {
+                "type": "boolean",
+                "title": "Do not treat tinyint(1) as boolean",
+                "default": false,
+                "description": "If enabled, properties of type TinyInt(1) are output as TinyInt, and not boolean."
+              }
             }
           }
-        }
-      ]
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
The spec format seems to have changed, according to [Airbyte's spec tester](https://components.airbyte.dev/?path=/story/connector-connectorform--preview&args=formType:source). Testing this spec output instead.

