### PR TITLE
Update pipeline Go to v1.22.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,7 +60,7 @@ steps:
     command: script/release.sh
     plugins:
       - docker#v3.8.0:
-          image: "golang:1.21.3"
+          image: "golang:1.22.2"
           propagate-environment: true
           environment:
             - "GITHUB_TOKEN"


### PR DESCRIPTION
Following https://github.com/planetscale/airbyte-source/commit/bb182841aec66304fad4db4caa3580a8cfb93e47 this PR updates the golang version in buildkite pipeline to `1.22.2` as well.