### PR TITLE
Fix `license_finder`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,7 @@ steps:
       - docker-compose#v3.9.0:
           run: ci
 
-  - name: "Verify dependency licenses %n"
+  - name: "Verify dependency licenses"
     command: "go get -v ./... && license_finder"
     env:
       DOCKER_BUILDKIT: 1

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.22.2
+ARG GO_VERSION=1.23.5
 FROM pscale.dev/wolfi-prod/go:${GO_VERSION} AS build
 
 RUN apk add --no-cache openssl openssl-dev libxcrypt ruby-3.2

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,7 +3,7 @@
 ARG GO_VERSION=1.22.2
 FROM pscale.dev/wolfi-prod/go:${GO_VERSION} AS build
 
-RUN apk add --no-cache openssl libxcrypt ruby-3.2
+RUN apk add --no-cache openssl openssl-dev libxcrypt ruby-3.2
 RUN gem install license_finder
 
 ENTRYPOINT []

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,7 +3,7 @@
 ARG GO_VERSION=1.23.5
 FROM pscale.dev/wolfi-prod/go:${GO_VERSION} AS build
 
-RUN apk add --no-cache openssl openssl-dev libxcrypt ruby-3.2
+RUN apk add --no-cache openssl openssl-dev libxcrypt ruby-3.2 ruby-3.2-dev
 RUN gem install openssl license_finder
 
 ENTRYPOINT []

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.23.5
+ARG GO_VERSION=1.22.11
 FROM pscale.dev/wolfi-prod/go:${GO_VERSION} AS build
 
 RUN apk add --no-cache openssl openssl-dev libxcrypt ruby-3.2 ruby-3.2-dev

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,7 +4,7 @@ ARG GO_VERSION=1.22.2
 FROM pscale.dev/wolfi-prod/go:${GO_VERSION} AS build
 
 RUN apk add --no-cache openssl libxcrypt ruby-3.2
-RUN arch -arm64 gem install license_finder
+RUN gem install license_finder
 
 ENTRYPOINT []
 WORKDIR /airbyte-source

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,7 +4,7 @@ ARG GO_VERSION=1.22.2
 FROM pscale.dev/wolfi-prod/go:${GO_VERSION} AS build
 
 RUN apk add --no-cache openssl openssl-dev libxcrypt ruby-3.2
-RUN gem install license_finder
+RUN gem install openssl license_finder
 
 ENTRYPOINT []
 WORKDIR /airbyte-source


### PR DESCRIPTION
Install the headers for Ruby and OpenSSL, bump to the latest version of go1.22.