### PR TITLE
Add configurable `max retries`, increase read timeout to 5 minutes

### DIFF
--- a/cmd/airbyte-source/spec.json
+++ b/cmd/airbyte-source/spec.json
@@ -66,6 +66,13 @@
           "description": "A JSON string containing start GTIDs for every { keyspace: { shard: starting_gtid } }",
           "order": 7
         },
+        "max_retries": {
+          "type": "integer",
+          "title": "Max retries",
+          "default": 3,
+          "description": "The max number of times we continue syncing after potential errors",
+          "order": 8
+        },
         "options": {
           "type": "object",
           "title": "Customize serialization",

--- a/cmd/internal/mock_types.go
+++ b/cmd/internal/mock_types.go
@@ -59,9 +59,14 @@ type vstreamClientMock struct {
 	vstreamFnInvokedCount int
 }
 
+type vstreamResponse struct {
+	response *vtgate.VStreamResponse
+	err      error
+}
+
 type vtgateVStreamClientMock struct {
 	lastResponseSent int
-	vstreamResponses []*vtgate.VStreamResponse
+	vstreamResponses []*vstreamResponse
 	grpc.ClientStream
 }
 
@@ -70,7 +75,7 @@ func (x *vtgateVStreamClientMock) Recv() (*vtgate.VStreamResponse, error) {
 		return nil, io.EOF
 	}
 	x.lastResponseSent += 1
-	return x.vstreamResponses[x.lastResponseSent-1], nil
+	return x.vstreamResponses[x.lastResponseSent-1].response, x.vstreamResponses[x.lastResponseSent-1].err
 }
 
 func (x *vstreamClientMock) CloseSession(context.Context, *vtgate.CloseSessionRequest, ...grpc.CallOption) (*vtgate.CloseSessionResponse, error) {

--- a/cmd/internal/planetscale_connection.go
+++ b/cmd/internal/planetscale_connection.go
@@ -21,6 +21,7 @@ type PlanetScaleSource struct {
 	UseRdonly     bool                `json:"use_rdonly"`
 	StartingGtids string              `json:"starting_gtids"`
 	Options       CustomSourceOptions `json:"options"`
+	MaxRetries    uint                `json:"max_retries"`
 }
 
 type CustomSourceOptions struct {

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -175,6 +175,7 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, w io.Writer, ps Plane
 		err                     error
 		sErr                    error
 		currentSerializedCursor *SerializedCursor
+		syncMode                string
 	)
 
 	tabletType := psdbconnect.TabletType_primary
@@ -185,59 +186,70 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, w io.Writer, ps Plane
 	}
 
 	currentPosition := lastKnownPosition
+	if currentPosition.Position == "" || currentPosition.LastKnownPk != nil {
+		syncMode = "full"
+	} else {
+		syncMode = "incremental"
+	}
+
 	table := s.Stream
-	readDuration := 1 * time.Minute
+	readDuration := 5 * time.Minute
+	maxRetries := ps.MaxRetries
+
 	preamble := fmt.Sprintf("[%v:%v:%v shard : %v] ", table.Namespace, TabletTypeToString(tabletType), table.Name, currentPosition.Shard)
 
+	p.Logger.Log(LOGLEVEL_INFO, preamble+"Peeking to see if there's any new GTIDs")
+	stopPosition, lcErr := p.getStopCursorPosition(ctx, currentPosition.Shard, currentPosition.Keyspace, table, ps, tabletType)
+	if lcErr != nil {
+		p.Logger.Log(LOGLEVEL_ERROR, preamble+fmt.Sprintf("Error fetching latest cursor position: %+v", lcErr))
+		return currentSerializedCursor, errors.Wrap(err, "Unable to get latest cursor position")
+	}
+	if stopPosition == "" {
+		p.Logger.Log(LOGLEVEL_ERROR, preamble+fmt.Sprintf("Error fetching latest cursor position, was empty string: %+v", stopPosition))
+		return currentSerializedCursor, errors.Wrap(err, "Unable to get latest cursor position")
+	}
+
+	// the last synced VGTID is not at least, or after the current VGTID
+	if currentPosition.Position != "" && !positionAfter(stopPosition, currentPosition.Position) {
+		p.Logger.Log(LOGLEVEL_INFO, preamble+"No new GTIDs found, exiting")
+		return TableCursorToSerializedCursor(currentPosition)
+	}
+	p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf(preamble+"New GTIDs found, syncing for %v", readDuration))
+
+	var syncCount uint = 0
+	totalRecordCount := 0
+
 	for {
-		p.Logger.Log(LOGLEVEL_INFO, preamble+"Peeking to see if there's any new rows")
-		latestCursorPosition, lcErr := p.getLatestCursorPosition(ctx, currentPosition.Shard, currentPosition.Keyspace, table, ps, tabletType)
-		if lcErr != nil {
-			p.Logger.Log(LOGLEVEL_ERROR, preamble+fmt.Sprintf("Error fetching latest cursor position: %+v", lcErr))
-			return currentSerializedCursor, errors.Wrap(err, "Unable to get latest cursor position")
-		}
-		if latestCursorPosition == "" {
-			p.Logger.Log(LOGLEVEL_ERROR, preamble+fmt.Sprintf("Error fetching latest cursor position, was empty string: %+v", latestCursorPosition))
-			return currentSerializedCursor, errors.Wrap(err, "Unable to get latest cursor position")
-		}
-
-		// the last synced VGTID is not at least, or after the current VGTID
-		if currentPosition.Position != "" && !positionAfter(latestCursorPosition, currentPosition.Position) {
-			p.Logger.Log(LOGLEVEL_INFO, preamble+"No new rows found, exiting")
-			return TableCursorToSerializedCursor(currentPosition)
-		}
-		p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf(preamble+"New rows found, syncing rows for %v", readDuration))
-		p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf(preamble+"Syncing rows from cursor [%v]", currentPosition))
-
-		currentPosition, recordCount, err := p.sync(ctx, currentPosition, latestCursorPosition, table, ps, tabletType, readDuration)
-		if currentPosition.Position != "" {
-			currentSerializedCursor, sErr = TableCursorToSerializedCursor(currentPosition)
-			if sErr != nil {
-				// if we failed to serialize here, we should bail.
-				return currentSerializedCursor, errors.Wrap(sErr, "unable to serialize current position")
-			}
+		syncCount += 1
+		p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sStarting sync #%v", preamble, syncCount))
+		newPosition, newStopPosition, recordCount, err := p.sync(ctx, syncMode, currentPosition, stopPosition, table, ps, tabletType, readDuration)
+		totalRecordCount += recordCount
+		currentSerializedCursor, sErr = TableCursorToSerializedCursor(currentPosition)
+		if sErr != nil {
+			// if we failed to serialize here, we should bail.
+			return currentSerializedCursor, errors.Wrap(sErr, "unable to serialize current position")
 		}
 		if err != nil {
 			if s, ok := status.FromError(err); ok {
-				// if the error is anything other than server timeout, keep going
-				if s.Code() != codes.DeadlineExceeded {
-					p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%vGot error [%v], returning with cursor [%v] after server timeout", preamble, s.Code(), currentPosition))
+				p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%v%v records synced after %v syncs. Got error [%v], returning with cursor [%v] after gRPC error", preamble, totalRecordCount, syncCount, s.Code(), currentPosition))
+				if syncCount >= maxRetries {
 					return currentSerializedCursor, nil
-				} else {
-					p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%v%v records synced. Continuing with cursor after recoverable error %+v", preamble, recordCount, err))
 				}
 			} else if errors.Is(err, io.EOF) {
-				p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%vFinished reading %v records for table [%v]", preamble, recordCount, table.Name))
+				p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%vFinished reading %v records after %v syncs for table [%v]", preamble, totalRecordCount, syncCount, table.Name))
 				return currentSerializedCursor, nil
 			} else {
-				p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%vNon-grpc error [%v]]", preamble, err))
+				p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%v%v records synced after %v syncs. Got error [%v], returning with cursor [%v] after server timeout", preamble, totalRecordCount, syncCount, err, currentPosition))
 				return currentSerializedCursor, err
 			}
 		}
+		currentPosition = newPosition
+		stopPosition = newStopPosition
+		p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%vContinuing to next sync #%v. Set next sync start position to [%+v] and next stop position to [%+v]", preamble, syncCount+1, currentPosition, stopPosition))
 	}
 }
 
-func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.TableCursor, stopPosition string, s Stream, ps PlanetScaleSource, tabletType psdbconnect.TabletType, readDuration time.Duration) (*psdbconnect.TableCursor, int, error) {
+func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, syncMode string, tc *psdbconnect.TableCursor, stopPosition string, s Stream, ps PlanetScaleSource, tabletType psdbconnect.TabletType, readDuration time.Duration) (*psdbconnect.TableCursor, string, int, error) {
 	preamble := fmt.Sprintf("[%v:%v:%v shard : %v] ", s.Namespace, TabletTypeToString(tabletType), s.Name, tc.Shard)
 
 	defer p.Logger.Flush()
@@ -247,33 +259,28 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 	var (
 		err          error
 		vtgateClient vtgateservice.VitessClient
+		fields       []*query.Field
 	)
 
 	vtgateClient, conn, err := p.initializeVTGateClient(ctx, ps)
 	if err != nil {
-		return tc, 0, err
+		return tc, stopPosition, 0, err
 	}
 	if conn != nil {
 		defer conn.Close()
 	}
 
-	// If there is a LastKnownPk, that means we were in a copy phase
-	// Setting position to "" specifies COPY phase in the VStream API
 	if tc.LastKnownPk != nil {
 		tc.Position = ""
 	}
 
-	waitForCopyCompleted := tc.Position == ""
-	copyCompletedSeen := false
-	p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sWill be waiting for COPY_COMPLETED event? %v", preamble, waitForCopyCompleted))
-
-	vtgateReq := buildVStreamRequest(tabletType, s.Name, tc.Shard, tc.Keyspace, tc.Position)
-	p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sRequesting to sync from cursor position [%v] to stop cursor position [%v] in cells %v; using last known PK: %v", preamble, tc.Position, stopPosition, vtgateReq.Flags.Cells, tc.LastKnownPk != nil))
+	vtgateReq := buildVStreamRequest(tabletType, s.Name, tc.Shard, tc.Keyspace, tc.Position, tc.LastKnownPk)
+	p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sRequesting VStream with %+v", preamble, vtgateReq))
 	c, err := vtgateClient.VStream(ctx, vtgateReq)
 
 	if err != nil {
 		p.Logger.Log(LOGLEVEL_ERROR, fmt.Sprintf("%sExiting sync due to client sync error: %+v", preamble, err))
-		return tc, 0, err
+		return tc, stopPosition, 0, err
 	}
 
 	keyspaceOrDatabase := s.Namespace
@@ -281,22 +288,27 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 		keyspaceOrDatabase = ps.Database
 	}
 
+	isFullSync := syncMode == "full"
+	copyCompletedSeen := false
 	// Can finish sync once we've synced to the stop position, or finished the VStream COPY phase
 	canFinishSync := false
 	resultCount := 0
 
-	var fields []*query.Field
-
 	for {
 		res, err := c.Recv()
 		if err != nil {
-			if s, ok := status.FromError(err); ok && s.Code() == codes.DeadlineExceeded && canFinishSync {
-				// No next VGTID found, but we previously found stop position or finished VStream COPY phase
-				p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sExiting sync and flushing records because no new VGTID found after stop position %+v", preamble, stopPosition))
-				return tc, resultCount, io.EOF
+			if s, ok := status.FromError(err); ok && s.Code() == codes.DeadlineExceeded {
+				// No next VGTID found
+				p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sExiting sync and flushing records because no new VGTID found after last position or deadline exceeded %+v", preamble, tc))
+				return tc, stopPosition, resultCount, err
+			} else if err == io.EOF {
+				// EOF is an acceptable error indicating VStream is finished.
+				p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sExiting sync and flushing records because EOF encountered at position %+v", preamble, tc))
+				return tc, stopPosition, resultCount, io.EOF
+			} else {
+				p.Logger.Log(LOGLEVEL_ERROR, fmt.Sprintf("%sExiting sync and flushing records due to error: %+v", preamble, err))
+				return tc, stopPosition, resultCount, err
 			}
-			p.Logger.Log(LOGLEVEL_ERROR, fmt.Sprintf("%sExiting sync and flushing records due to error: %+v", preamble, err))
-			return tc, resultCount, err
 		}
 
 		var rows []*query.QueryResult
@@ -305,11 +317,16 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 			case binlogdata.VEventType_VGTID:
 				vgtid := event.GetVgtid().ShardGtids[0]
 				if vgtid != nil {
-					// Update cursor to new VGTID
-					tc = &psdbconnect.TableCursor{
-						Shard:    tc.Shard,
-						Keyspace: tc.Keyspace,
-						Position: vgtid.Gtid,
+					tc.Position = vgtid.Gtid
+					if vgtid.TablePKs != nil {
+						tablePK := vgtid.TablePKs[0]
+						if tablePK != nil {
+							// Setting LastKnownPk allows a COPY phase to pick up where it left off
+							lastPK := tablePK.Lastpk
+							tc.LastKnownPk = lastPK
+						} else {
+							tc.LastKnownPk = nil
+						}
 					}
 				}
 			case binlogdata.VEventType_LASTPK:
@@ -343,19 +360,20 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 			}
 		}
 
-		if waitForCopyCompleted && copyCompletedSeen {
-			p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sReady to finish sync and flush since copy phase completed.", preamble))
+		// if isFullSync && copyCompletedSeen {
+		if isFullSync && copyCompletedSeen {
+			p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sReady to finish sync and flush since copy phase completed or stop VGTID passed", preamble))
 			canFinishSync = true
 		}
-		if !waitForCopyCompleted && positionEqual(tc.Position, stopPosition) {
-			p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sReady to finish sync and flush since stop position [%+v] found.", preamble, stopPosition))
+		if !isFullSync && positionEqual(tc.Position, stopPosition) {
+			p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sReady to finish sync and flush since stop position [%+v] found", preamble, stopPosition))
 			canFinishSync = true
 		}
 
 		// Exit sync and flush records once the VGTID position is past the desired stop position, and we're no longer waiting for COPY phase to complete
 		if canFinishSync && positionAfter(tc.Position, stopPosition) {
 			p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sExiting sync and flushing records because current position %+v has passed stop position %+v", preamble, tc.Position, stopPosition))
-			return tc, resultCount, io.EOF
+			return tc, stopPosition, resultCount, io.EOF
 		}
 
 		if len(rows) > 0 {
@@ -373,10 +391,9 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 			}
 		}
 	}
-
 }
 
-func (p PlanetScaleEdgeDatabase) getLatestCursorPosition(ctx context.Context, shard, keyspace string, s Stream, ps PlanetScaleSource, tabletType psdbconnect.TabletType) (string, error) {
+func (p PlanetScaleEdgeDatabase) getStopCursorPosition(ctx context.Context, shard, keyspace string, s Stream, ps PlanetScaleSource, tabletType psdbconnect.TabletType) (string, error) {
 	defer p.Logger.Flush()
 	timeout := 45 * time.Second
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -394,7 +411,7 @@ func (p PlanetScaleEdgeDatabase) getLatestCursorPosition(ctx context.Context, sh
 		defer conn.Close()
 	}
 
-	vtgateReq := buildVStreamRequest(tabletType, s.Name, shard, keyspace, "current")
+	vtgateReq := buildVStreamRequest(tabletType, s.Name, shard, keyspace, "current", nil)
 	vtgateCursor, vtgateErr := vtgateClient.VStream(ctx, vtgateReq)
 
 	if vtgateErr != nil {
@@ -465,7 +482,7 @@ func (p PlanetScaleEdgeDatabase) printQueryResult(qr *sqltypes.Result, tableName
 	}
 }
 
-func buildVStreamRequest(tabletType psdbconnect.TabletType, table string, shard string, keyspace string, gtid string) *vtgate.VStreamRequest {
+func buildVStreamRequest(tabletType psdbconnect.TabletType, table string, shard string, keyspace string, gtid string, lastKnownPk *query.QueryResult) *vtgate.VStreamRequest {
 	return &vtgate.VStreamRequest{
 		TabletType: toTopoTabletType(tabletType),
 		Vgtid: &binlogdata.VGtid{
@@ -474,6 +491,12 @@ func buildVStreamRequest(tabletType psdbconnect.TabletType, table string, shard 
 					Shard:    shard,
 					Keyspace: keyspace,
 					Gtid:     gtid,
+					TablePKs: []*binlogdata.TableLastPK{
+						{
+							TableName: table,
+							Lastpk:    lastKnownPk,
+						},
+					},
 				},
 			},
 		},

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -960,7 +960,7 @@ func TestRead_IncrementalSync_CanStopAtWellKnownCursor(t *testing.T) {
 	assert.Equal(t, 10, len(responses))
 	logLines := tal.logMessages[LOGLEVEL_INFO]
 	// But only the first 8 (with VGtids <= stop position) will be synced
-	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] Finished reading %v records for table [customers]", 8), logLines[len(logLines)-1])
+	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] Finished reading %v records after 1 syncs for table [customers]", 8), logLines[len(logLines)-1])
 	records := tal.records["connect-test.customers"]
 	assert.Equal(t, 8, len(records))
 }
@@ -1577,7 +1577,7 @@ func TestRead_FullSync_CanStopSyncPastStopPosition(t *testing.T) {
 	assert.Equal(t, 2, vsc.vstreamFnInvokedCount)
 
 	logLines := tal.logMessages[LOGLEVEL_INFO]
-	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] Finished reading %v records for table [customers]", 10), logLines[len(logLines)-1])
+	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] Finished reading %v records after 1 syncs for table [customers]", 10), logLines[len(logLines)-1])
 	records := tal.records["connect-test.customers"]
 	assert.Equal(t, 10, len(records))
 }
@@ -1791,7 +1791,7 @@ func TestRead_FullSync_CanStopSyncEqualToStopPosition(t *testing.T) {
 	assert.Equal(t, 2, vsc.vstreamFnInvokedCount)
 
 	logLines := tal.logMessages[LOGLEVEL_INFO]
-	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] Finished reading %v records for table [customers]", 10), logLines[len(logLines)-1])
+	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] Finished reading %v records after 1 syncs for table [customers]", 10), logLines[len(logLines)-1])
 	records := tal.records["connect-test.customers"]
 	assert.Equal(t, 10, len(records))
 }
@@ -2111,7 +2111,7 @@ func TestRead_FullSync_CopyCatchupLoop(t *testing.T) {
 	assert.Equal(t, 2, vsc.vstreamFnInvokedCount)
 
 	logLines := tal.logMessages[LOGLEVEL_INFO]
-	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] Finished reading %v records for table [customers]", 22), logLines[len(logLines)-1])
+	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] Finished reading %v records after 1 syncs for table [customers]", 22), logLines[len(logLines)-1])
 	records := tal.records["connect-test.customers"]
 	assert.Equal(t, 22, len(records))
 }

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -2511,7 +2511,7 @@ func TestRead_FullSync_MaxRetries(t *testing.T) {
 	assert.Equal(t, 4, vsc.vstreamFnInvokedCount)
 
 	logLines := tal.logMessages[LOGLEVEL_INFO]
-	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] %v records synced after 3 syncs. Got error [DeadlineExceeded], returning with cursor [shard:\"-\" keyspace:\"connect-test\" position:\"MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-10\"] after gRPC error", 30), logLines[len(logLines)-1])
+	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] %v records synced after 3 syncs. Got error [DeadlineExceeded], returning with cursor [shard:\"-\"  keyspace:\"connect-test\"  position:\"MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-10\"] after gRPC error", 30), logLines[len(logLines)-1])
 	records := tal.records["connect-test.customers"]
 	assert.Equal(t, 30, len(records))
 }

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
@@ -2597,7 +2598,7 @@ func TestRead_FullSync_MaxRetries(t *testing.T) {
 	assert.Equal(t, 4, vsc.vstreamFnInvokedCount)
 
 	logLines := tal.logMessages[LOGLEVEL_INFO]
-	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] %v records synced after 3 syncs. Got error [DeadlineExceeded], returning with cursor [shard:\"-\"  keyspace:\"connect-test\"  position:\"MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-10\"  last_known_pk:{fields:{name:\"id\"  type:INT64  charset:63  flags:53251}  rows:{lengths:4  values:\"30\"}}] after gRPC error", 30), logLines[len(logLines)-1])
+	assert.Equal(t, strings.TrimSpace(fmt.Sprintf("[connect-test:primary:customers shard : -] %v records synced after 3 syncs. Got error [DeadlineExceeded], returning with cursor [shard:\"-\"  keyspace:\"connect-test\"  position:\"MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-10\"  last_known_pk:{fields:{name:\"id\"  type:INT64  charset:63  flags:53251}  rows:{lengths:4  values:\"30\"}}] after gRPC error", 30)), strings.TrimSpace(logLines[len(logLines)-1]))
 	records := tal.records["connect-test.customers"]
 	assert.Equal(t, 30, len(records))
 }

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -32,22 +32,24 @@ func TestRead_CanPeekBeforeRead(t *testing.T) {
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    "-",
-									Gtid:     "THIS_IS_A_SHARD_GTID",
-									Keyspace: "connect-test",
-								},
-								{
-									Shard:    "-",
-									Gtid:     "THIS_IS_A_SHARD_GTID",
-									Keyspace: "connect-test",
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    "-",
+										Gtid:     "THIS_IS_A_SHARD_GTID",
+										Keyspace: "connect-test",
+									},
+									{
+										Shard:    "-",
+										Gtid:     "THIS_IS_A_SHARD_GTID",
+										Keyspace: "connect-test",
+									},
 								},
 							},
 						},
@@ -98,22 +100,24 @@ func TestRead_CanEarlyExitIfNoNewVGtidInPeek(t *testing.T) {
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    "-",
-									Gtid:     "THIS_IS_A_SHARD_GTID",
-									Keyspace: "connect-test",
-								},
-								{
-									Shard:    "-",
-									Gtid:     "THIS_IS_A_SHARD_GTID",
-									Keyspace: "connect-test",
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    "-",
+										Gtid:     "THIS_IS_A_SHARD_GTID",
+										Keyspace: "connect-test",
+									},
+									{
+										Shard:    "-",
+										Gtid:     "THIS_IS_A_SHARD_GTID",
+										Keyspace: "connect-test",
+									},
 								},
 							},
 						},
@@ -162,17 +166,19 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    tc.Shard,
-									Gtid:     tc.Position,
-									Keyspace: tc.Keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    tc.Shard,
+										Gtid:     tc.Position,
+										Keyspace: tc.Keyspace,
+									},
 								},
 							},
 						},
@@ -227,17 +233,19 @@ func TestRead_CanPickReplicaForShardedKeyspaces(t *testing.T) {
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    tc.Shard,
-									Gtid:     tc.Position,
-									Keyspace: tc.Keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    tc.Shard,
+										Gtid:     tc.Position,
+										Keyspace: tc.Keyspace,
+									},
 								},
 							},
 						},
@@ -292,17 +300,19 @@ func TestRead_CanPickRdonlyForShardedKeyspaces(t *testing.T) {
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    tc.Shard,
-									Gtid:     tc.Position,
-									Keyspace: tc.Keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    tc.Shard,
+										Gtid:     tc.Position,
+										Keyspace: tc.Keyspace,
+									},
 								},
 							},
 						},
@@ -486,17 +496,19 @@ func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    tc.Shard,
-									Gtid:     tc.Position,
-									Keyspace: tc.Keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    tc.Shard,
+										Gtid:     tc.Position,
+										Keyspace: tc.Keyspace,
+									},
 								},
 							},
 						},
@@ -550,17 +562,19 @@ func TestRead_CanPickReplicaForUnshardedKeyspaces(t *testing.T) {
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    tc.Shard,
-									Gtid:     tc.Position,
-									Keyspace: tc.Keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    tc.Shard,
+										Gtid:     tc.Position,
+										Keyspace: tc.Keyspace,
+									},
 								},
 							},
 						},
@@ -616,17 +630,19 @@ func TestRead_IncrementalSync_CanReturnOriginalCursorIfNoNewFound(t *testing.T) 
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    tc.Shard,
-									Gtid:     tc.Position,
-									Keyspace: tc.Keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    tc.Shard,
+										Gtid:     tc.Position,
+										Keyspace: tc.Keyspace,
+									},
 								},
 							},
 						},
@@ -684,18 +700,19 @@ func TestRead_IncrementalSync_CanReturnNewCursorIfNewFound(t *testing.T) {
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
-			// First sync to get end position
+		vstreamResponses: []*vstreamResponse{
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    newTC.Shard,
-									Gtid:     newTC.Position,
-									Keyspace: newTC.Keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    newTC.Shard,
+										Gtid:     newTC.Position,
+										Keyspace: newTC.Keyspace,
+									},
 								},
 							},
 						},
@@ -704,15 +721,17 @@ func TestRead_IncrementalSync_CanReturnNewCursorIfNewFound(t *testing.T) {
 			},
 			// First recv() of second sync for rows
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    newTC.Shard,
-									Gtid:     newTC.Position,
-									Keyspace: newTC.Keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    newTC.Shard,
+										Gtid:     newTC.Position,
+										Keyspace: newTC.Keyspace,
+									},
 								},
 							},
 						},
@@ -721,16 +740,18 @@ func TestRead_IncrementalSync_CanReturnNewCursorIfNewFound(t *testing.T) {
 			},
 			// Second recv() of second sync for rows
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_ROW,
-						RowEvent: &binlogdata.RowEvent{
-							TableName: "customers",
-							Keyspace:  newTC.Keyspace,
-							Shard:     newTC.Shard,
-							RowChanges: []*binlogdata.RowChange{
-								{
-									After: &query.Row{Values: []byte("1,my_name")},
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_ROW,
+							RowEvent: &binlogdata.RowEvent{
+								TableName: "customers",
+								Keyspace:  newTC.Keyspace,
+								Shard:     newTC.Shard,
+								RowChanges: []*binlogdata.RowChange{
+									{
+										After: &query.Row{Values: []byte("1,my_name")},
+									},
 								},
 							},
 						},
@@ -783,57 +804,59 @@ func TestRead_IncrementalSync_CanStopAtWellKnownCursor(t *testing.T) {
 	keyspace := "connect-test"
 	table := "customers"
 	database := "connect-test"
-	responses := []*vtgate.VStreamResponse{
+	responses := []*vstreamResponse{
 		{
-			Events: []*binlogdata.VEvent{
-				{
-					Type:     binlogdata.VEventType_BEGIN,
-					Keyspace: keyspace,
-					Shard:    shard,
-				},
-				{
-					Type:     binlogdata.VEventType_VGTID,
-					Keyspace: keyspace,
-					Shard:    shard,
-					Vgtid: &binlogdata.VGtid{
-						ShardGtids: []*binlogdata.ShardGtid{
-							{
-								Keyspace: keyspace,
-								Shard:    shard,
-								Gtid:     fmt.Sprintf("MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", 0),
+			response: &vtgate.VStreamResponse{
+				Events: []*binlogdata.VEvent{
+					{
+						Type:     binlogdata.VEventType_BEGIN,
+						Keyspace: keyspace,
+						Shard:    shard,
+					},
+					{
+						Type:     binlogdata.VEventType_VGTID,
+						Keyspace: keyspace,
+						Shard:    shard,
+						Vgtid: &binlogdata.VGtid{
+							ShardGtids: []*binlogdata.ShardGtid{
+								{
+									Keyspace: keyspace,
+									Shard:    shard,
+									Gtid:     fmt.Sprintf("MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", 0),
+								},
 							},
 						},
 					},
-				},
-				{
-					Type:     binlogdata.VEventType_COMMIT,
-					Keyspace: keyspace,
-					Shard:    shard,
-				},
-				{
-					Type: binlogdata.VEventType_FIELD,
-					FieldEvent: &binlogdata.FieldEvent{
-						TableName: table,
-						Fields: []*query.Field{
-							{
-								Name:         "id",
-								Type:         query.Type_INT64,
-								Table:        table,
-								OrgTable:     table,
-								Database:     database,
-								ColumnLength: 20,
-								Charset:      63,
-								ColumnType:   "bigint",
-							},
-							{
-								Name:         "product",
-								Type:         query.Type_VARCHAR,
-								Table:        table,
-								OrgTable:     table,
-								Database:     database,
-								ColumnLength: 1024,
-								Charset:      255,
-								ColumnType:   "varchar(256)",
+					{
+						Type:     binlogdata.VEventType_COMMIT,
+						Keyspace: keyspace,
+						Shard:    shard,
+					},
+					{
+						Type: binlogdata.VEventType_FIELD,
+						FieldEvent: &binlogdata.FieldEvent{
+							TableName: table,
+							Fields: []*query.Field{
+								{
+									Name:         "id",
+									Type:         query.Type_INT64,
+									Table:        table,
+									OrgTable:     table,
+									Database:     database,
+									ColumnLength: 20,
+									Charset:      63,
+									ColumnType:   "bigint",
+								},
+								{
+									Name:         "product",
+									Type:         query.Type_VARCHAR,
+									Table:        table,
+									OrgTable:     table,
+									Database:     database,
+									ColumnLength: 1024,
+									Charset:      255,
+									ColumnType:   "varchar(256)",
+								},
 							},
 						},
 					},
@@ -842,63 +865,66 @@ func TestRead_IncrementalSync_CanStopAtWellKnownCursor(t *testing.T) {
 		},
 	}
 	for i := 1; i < numRows; i++ {
-		response := vtgate.VStreamResponse{
-			Events: []*binlogdata.VEvent{
-				{
-					Type:     binlogdata.VEventType_BEGIN,
-					Keyspace: keyspace,
-					Shard:    shard,
-				},
-				{
-					Type: binlogdata.VEventType_ROW,
-					RowEvent: &binlogdata.RowEvent{
-						TableName: table,
-						RowChanges: []*binlogdata.RowChange{
-							{
-								After: &query.Row{
-									Values: []byte(fmt.Sprintf("%v,keyboard", i)),
+		response := &vstreamResponse{
+			response: &vtgate.VStreamResponse{
+				Events: []*binlogdata.VEvent{
+					{
+						Type:     binlogdata.VEventType_BEGIN,
+						Keyspace: keyspace,
+						Shard:    shard,
+					},
+					{
+						Type: binlogdata.VEventType_ROW,
+						RowEvent: &binlogdata.RowEvent{
+							TableName: table,
+							RowChanges: []*binlogdata.RowChange{
+								{
+									After: &query.Row{
+										Values: []byte(fmt.Sprintf("%v,keyboard", i)),
+									},
 								},
 							},
 						},
 					},
-				},
-				{
-					Type:     binlogdata.VEventType_VGTID,
-					Keyspace: keyspace,
-					Shard:    shard,
-					Vgtid: &binlogdata.VGtid{
-						ShardGtids: []*binlogdata.ShardGtid{
-							{
-								Keyspace: keyspace,
-								Shard:    shard,
-								Gtid:     fmt.Sprintf("MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", i),
-							},
-						},
-					},
-				},
-				{
-					Type:     binlogdata.VEventType_COMMIT,
-					Keyspace: keyspace,
-					Shard:    shard,
-				},
-			},
-		}
-		responses = append(responses, &response)
-	}
-
-	getCurrentVGtidClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
-			// First sync to get stop position
-			{
-				Events: []*binlogdata.VEvent{
 					{
-						Type: binlogdata.VEventType_VGTID,
+						Type:     binlogdata.VEventType_VGTID,
+						Keyspace: keyspace,
+						Shard:    shard,
 						Vgtid: &binlogdata.VGtid{
 							ShardGtids: []*binlogdata.ShardGtid{
 								{
-									Shard:    shard,
-									Gtid:     stopVGtidPosition,
 									Keyspace: keyspace,
+									Shard:    shard,
+									Gtid:     fmt.Sprintf("MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", i),
+								},
+							},
+						},
+					},
+					{
+						Type:     binlogdata.VEventType_COMMIT,
+						Keyspace: keyspace,
+						Shard:    shard,
+					},
+				},
+			},
+		}
+		responses = append(responses, response)
+	}
+
+	getCurrentVGtidClient := &vtgateVStreamClientMock{
+		vstreamResponses: []*vstreamResponse{
+			{
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     stopVGtidPosition,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -988,18 +1014,20 @@ func TestRead_IncrementalSync_CanLogResults(t *testing.T) {
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			// First sync to get stop position
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     stopVGtid,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     stopVGtid,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -1008,15 +1036,17 @@ func TestRead_IncrementalSync_CanLogResults(t *testing.T) {
 			},
 			// 1st recv() of second sync for rows to get start VGtid
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     startVGtid,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     startVGtid,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -1025,15 +1055,17 @@ func TestRead_IncrementalSync_CanLogResults(t *testing.T) {
 			},
 			// 2nd recv() of second sync for rows to get stop VGtid
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     stopVGtid,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     stopVGtid,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -1042,31 +1074,33 @@ func TestRead_IncrementalSync_CanLogResults(t *testing.T) {
 			},
 			// 3rd recv() for second sync for rows to get fields
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_FIELD,
-						FieldEvent: &binlogdata.FieldEvent{
-							TableName: table,
-							Fields: []*query.Field{
-								{
-									Name:         "pid",
-									Type:         query.Type_INT64,
-									Table:        table,
-									OrgTable:     table,
-									Database:     keyspace,
-									ColumnLength: 20,
-									Charset:      63,
-									ColumnType:   "bigint",
-								},
-								{
-									Name:         "description",
-									Type:         query.Type_VARCHAR,
-									Table:        table,
-									OrgTable:     table,
-									Database:     keyspace,
-									ColumnLength: 1024,
-									Charset:      255,
-									ColumnType:   "varchar(256)",
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_FIELD,
+							FieldEvent: &binlogdata.FieldEvent{
+								TableName: table,
+								Fields: []*query.Field{
+									{
+										Name:         "pid",
+										Type:         query.Type_INT64,
+										Table:        table,
+										OrgTable:     table,
+										Database:     keyspace,
+										ColumnLength: 20,
+										Charset:      63,
+										ColumnType:   "bigint",
+									},
+									{
+										Name:         "description",
+										Type:         query.Type_VARCHAR,
+										Table:        table,
+										OrgTable:     table,
+										Database:     keyspace,
+										ColumnLength: 1024,
+										Charset:      255,
+										ColumnType:   "varchar(256)",
+									},
 								},
 							},
 						},
@@ -1075,24 +1109,26 @@ func TestRead_IncrementalSync_CanLogResults(t *testing.T) {
 			},
 			// 4th recv() of second sync for rows to get records
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_ROW,
-						RowEvent: &binlogdata.RowEvent{
-							TableName: table,
-							Keyspace:  keyspace,
-							Shard:     shard,
-							RowChanges: []*binlogdata.RowChange{
-								{
-									After: &query.Row{
-										Lengths: []int64{1, 8},
-										Values:  []byte("1keyboard"),
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_ROW,
+							RowEvent: &binlogdata.RowEvent{
+								TableName: table,
+								Keyspace:  keyspace,
+								Shard:     shard,
+								RowChanges: []*binlogdata.RowChange{
+									{
+										After: &query.Row{
+											Lengths: []int64{1, 8},
+											Values:  []byte("1keyboard"),
+										},
 									},
-								},
-								{
-									After: &query.Row{
-										Lengths: []int64{1, 7},
-										Values:  []byte("2monitor"),
+									{
+										After: &query.Row{
+											Lengths: []int64{1, 7},
+											Values:  []byte("2monitor"),
+										},
 									},
 								},
 							},
@@ -1102,15 +1138,17 @@ func TestRead_IncrementalSync_CanLogResults(t *testing.T) {
 			},
 			// 5th recv() of second sync for rows to advance GTid past stop position
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     nextVGtid,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     nextVGtid,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -1119,24 +1157,26 @@ func TestRead_IncrementalSync_CanLogResults(t *testing.T) {
 			},
 			// Will not reach this event since stop position passed
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_ROW,
-						RowEvent: &binlogdata.RowEvent{
-							TableName: table,
-							Keyspace:  keyspace,
-							Shard:     shard,
-							RowChanges: []*binlogdata.RowChange{
-								{
-									After: &query.Row{
-										Lengths: []int64{1, 8},
-										Values:  []byte("1keyboard"),
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_ROW,
+							RowEvent: &binlogdata.RowEvent{
+								TableName: table,
+								Keyspace:  keyspace,
+								Shard:     shard,
+								RowChanges: []*binlogdata.RowChange{
+									{
+										After: &query.Row{
+											Lengths: []int64{1, 8},
+											Values:  []byte("1keyboard"),
+										},
 									},
-								},
-								{
-									After: &query.Row{
-										Lengths: []int64{1, 7},
-										Values:  []byte("2monitor"),
+									{
+										After: &query.Row{
+											Lengths: []int64{1, 7},
+											Values:  []byte("2monitor"),
+										},
 									},
 								},
 							},
@@ -1216,18 +1256,20 @@ func TestRead_IncrementalSync_CanStopIfNoRows(t *testing.T) {
 	}
 
 	vstreamSyncClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			// First sync to get stop position
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     stopVGtid,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     stopVGtid,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -1236,15 +1278,17 @@ func TestRead_IncrementalSync_CanStopIfNoRows(t *testing.T) {
 			},
 			// 1st recv() of second sync for rows to get start VGtid
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     startVGtid,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     startVGtid,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -1253,15 +1297,17 @@ func TestRead_IncrementalSync_CanStopIfNoRows(t *testing.T) {
 			},
 			// 2nd recv() of second sync for rows to get stop VGtid
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     stopVGtid,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     stopVGtid,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -1270,15 +1316,17 @@ func TestRead_IncrementalSync_CanStopIfNoRows(t *testing.T) {
 			},
 			// 3rd recv() of second sync for rows to advance GTid past stop position
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     nextVGtid,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     nextVGtid,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -1287,24 +1335,26 @@ func TestRead_IncrementalSync_CanStopIfNoRows(t *testing.T) {
 			},
 			// Will not reach this event since stop position passed
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_ROW,
-						RowEvent: &binlogdata.RowEvent{
-							TableName: table,
-							Keyspace:  keyspace,
-							Shard:     shard,
-							RowChanges: []*binlogdata.RowChange{
-								{
-									After: &query.Row{
-										Lengths: []int64{1, 8},
-										Values:  []byte("1keyboard"),
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_ROW,
+							RowEvent: &binlogdata.RowEvent{
+								TableName: table,
+								Keyspace:  keyspace,
+								Shard:     shard,
+								RowChanges: []*binlogdata.RowChange{
+									{
+										After: &query.Row{
+											Lengths: []int64{1, 8},
+											Values:  []byte("1keyboard"),
+										},
 									},
-								},
-								{
-									After: &query.Row{
-										Lengths: []int64{1, 7},
-										Values:  []byte("2monitor"),
+									{
+										After: &query.Row{
+											Lengths: []int64{1, 7},
+											Values:  []byte("2monitor"),
+										},
 									},
 								},
 							},
@@ -1401,57 +1451,59 @@ func TestRead_FullSync_CanStopSyncPastStopPosition(t *testing.T) {
 	table := "customers"
 	database := "connect-test"
 
-	responses := []*vtgate.VStreamResponse{
+	responses := []*vstreamResponse{
 		{
-			Events: []*binlogdata.VEvent{
-				{
-					Type:     binlogdata.VEventType_BEGIN,
-					Keyspace: keyspace,
-					Shard:    shard,
-				},
-				{
-					Type:     binlogdata.VEventType_VGTID,
-					Keyspace: keyspace,
-					Shard:    shard,
-					Vgtid: &binlogdata.VGtid{
-						ShardGtids: []*binlogdata.ShardGtid{
-							{
-								Keyspace: keyspace,
-								Shard:    shard,
-								Gtid:     fmt.Sprintf("MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", 9),
+			response: &vtgate.VStreamResponse{
+				Events: []*binlogdata.VEvent{
+					{
+						Type:     binlogdata.VEventType_BEGIN,
+						Keyspace: keyspace,
+						Shard:    shard,
+					},
+					{
+						Type:     binlogdata.VEventType_VGTID,
+						Keyspace: keyspace,
+						Shard:    shard,
+						Vgtid: &binlogdata.VGtid{
+							ShardGtids: []*binlogdata.ShardGtid{
+								{
+									Keyspace: keyspace,
+									Shard:    shard,
+									Gtid:     fmt.Sprintf("MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", 9),
+								},
 							},
 						},
 					},
-				},
-				{
-					Type:     binlogdata.VEventType_COMMIT,
-					Keyspace: keyspace,
-					Shard:    shard,
-				},
-				{
-					Type: binlogdata.VEventType_FIELD,
-					FieldEvent: &binlogdata.FieldEvent{
-						TableName: table,
-						Fields: []*query.Field{
-							{
-								Name:         "id",
-								Type:         query.Type_INT64,
-								Table:        table,
-								OrgTable:     table,
-								Database:     database,
-								ColumnLength: 20,
-								Charset:      63,
-								ColumnType:   "bigint",
-							},
-							{
-								Name:         "product",
-								Type:         query.Type_VARCHAR,
-								Table:        table,
-								OrgTable:     table,
-								Database:     database,
-								ColumnLength: 1024,
-								Charset:      255,
-								ColumnType:   "varchar(256)",
+					{
+						Type:     binlogdata.VEventType_COMMIT,
+						Keyspace: keyspace,
+						Shard:    shard,
+					},
+					{
+						Type: binlogdata.VEventType_FIELD,
+						FieldEvent: &binlogdata.FieldEvent{
+							TableName: table,
+							Fields: []*query.Field{
+								{
+									Name:         "id",
+									Type:         query.Type_INT64,
+									Table:        table,
+									OrgTable:     table,
+									Database:     database,
+									ColumnLength: 20,
+									Charset:      63,
+									ColumnType:   "bigint",
+								},
+								{
+									Name:         "product",
+									Type:         query.Type_VARCHAR,
+									Table:        table,
+									OrgTable:     table,
+									Database:     database,
+									ColumnLength: 1024,
+									Charset:      255,
+									ColumnType:   "varchar(256)",
+								},
 							},
 						},
 					},
@@ -1459,12 +1511,14 @@ func TestRead_FullSync_CanStopSyncPastStopPosition(t *testing.T) {
 			},
 		},
 	}
-	rowResponse := vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type:     binlogdata.VEventType_BEGIN,
-				Keyspace: keyspace,
-				Shard:    shard,
+	rowResponse := vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type:     binlogdata.VEventType_BEGIN,
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
 			},
 		},
 	}
@@ -1482,31 +1536,35 @@ func TestRead_FullSync_CanStopSyncPastStopPosition(t *testing.T) {
 				},
 			},
 		}
-		rowResponse.Events = append(rowResponse.Events, &event)
+		rowResponse.response.Events = append(rowResponse.response.Events, &event)
 	}
 
 	responses = append(responses, &rowResponse)
 
-	responses = append(responses, &vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type: binlogdata.VEventType_COPY_COMPLETED,
+	responses = append(responses, &vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type: binlogdata.VEventType_COPY_COMPLETED,
+				},
 			},
 		},
 	})
 
-	responses = append(responses, &vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type:     binlogdata.VEventType_VGTID,
-				Keyspace: keyspace,
-				Shard:    shard,
-				Vgtid: &binlogdata.VGtid{
-					ShardGtids: []*binlogdata.ShardGtid{
-						{
-							Keyspace: keyspace,
-							Shard:    shard,
-							Gtid:     "MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-10",
+	responses = append(responses, &vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type:     binlogdata.VEventType_VGTID,
+					Keyspace: keyspace,
+					Shard:    shard,
+					Vgtid: &binlogdata.VGtid{
+						ShardGtids: []*binlogdata.ShardGtid{
+							{
+								Keyspace: keyspace,
+								Shard:    shard,
+								Gtid:     "MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-10",
+							},
 						},
 					},
 				},
@@ -1515,18 +1573,20 @@ func TestRead_FullSync_CanStopSyncPastStopPosition(t *testing.T) {
 	})
 
 	getCurrentVGtidClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			// First sync to get stop position
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     stopVGtidPosition,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     stopVGtidPosition,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -1615,57 +1675,59 @@ func TestRead_FullSync_CanStopSyncEqualToStopPosition(t *testing.T) {
 	table := "customers"
 	database := "connect-test"
 
-	responses := []*vtgate.VStreamResponse{
+	responses := []*vstreamResponse{
 		{
-			Events: []*binlogdata.VEvent{
-				{
-					Type:     binlogdata.VEventType_BEGIN,
-					Keyspace: keyspace,
-					Shard:    shard,
-				},
-				{
-					Type:     binlogdata.VEventType_VGTID,
-					Keyspace: keyspace,
-					Shard:    shard,
-					Vgtid: &binlogdata.VGtid{
-						ShardGtids: []*binlogdata.ShardGtid{
-							{
-								Keyspace: keyspace,
-								Shard:    shard,
-								Gtid:     stopVGtidPosition,
+			response: &vtgate.VStreamResponse{
+				Events: []*binlogdata.VEvent{
+					{
+						Type:     binlogdata.VEventType_BEGIN,
+						Keyspace: keyspace,
+						Shard:    shard,
+					},
+					{
+						Type:     binlogdata.VEventType_VGTID,
+						Keyspace: keyspace,
+						Shard:    shard,
+						Vgtid: &binlogdata.VGtid{
+							ShardGtids: []*binlogdata.ShardGtid{
+								{
+									Keyspace: keyspace,
+									Shard:    shard,
+									Gtid:     stopVGtidPosition,
+								},
 							},
 						},
 					},
-				},
-				{
-					Type:     binlogdata.VEventType_COMMIT,
-					Keyspace: keyspace,
-					Shard:    shard,
-				},
-				{
-					Type: binlogdata.VEventType_FIELD,
-					FieldEvent: &binlogdata.FieldEvent{
-						TableName: table,
-						Fields: []*query.Field{
-							{
-								Name:         "id",
-								Type:         query.Type_INT64,
-								Table:        table,
-								OrgTable:     table,
-								Database:     database,
-								ColumnLength: 20,
-								Charset:      63,
-								ColumnType:   "bigint",
-							},
-							{
-								Name:         "product",
-								Type:         query.Type_VARCHAR,
-								Table:        table,
-								OrgTable:     table,
-								Database:     database,
-								ColumnLength: 1024,
-								Charset:      255,
-								ColumnType:   "varchar(256)",
+					{
+						Type:     binlogdata.VEventType_COMMIT,
+						Keyspace: keyspace,
+						Shard:    shard,
+					},
+					{
+						Type: binlogdata.VEventType_FIELD,
+						FieldEvent: &binlogdata.FieldEvent{
+							TableName: table,
+							Fields: []*query.Field{
+								{
+									Name:         "id",
+									Type:         query.Type_INT64,
+									Table:        table,
+									OrgTable:     table,
+									Database:     database,
+									ColumnLength: 20,
+									Charset:      63,
+									ColumnType:   "bigint",
+								},
+								{
+									Name:         "product",
+									Type:         query.Type_VARCHAR,
+									Table:        table,
+									OrgTable:     table,
+									Database:     database,
+									ColumnLength: 1024,
+									Charset:      255,
+									ColumnType:   "varchar(256)",
+								},
 							},
 						},
 					},
@@ -1673,12 +1735,14 @@ func TestRead_FullSync_CanStopSyncEqualToStopPosition(t *testing.T) {
 			},
 		},
 	}
-	rowResponse := vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type:     binlogdata.VEventType_BEGIN,
-				Keyspace: keyspace,
-				Shard:    shard,
+	rowResponse := vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type:     binlogdata.VEventType_BEGIN,
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
 			},
 		},
 	}
@@ -1696,31 +1760,35 @@ func TestRead_FullSync_CanStopSyncEqualToStopPosition(t *testing.T) {
 				},
 			},
 		}
-		rowResponse.Events = append(rowResponse.Events, &event)
+		rowResponse.response.Events = append(rowResponse.response.Events, &event)
 	}
 
 	responses = append(responses, &rowResponse)
 
-	responses = append(responses, &vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type: binlogdata.VEventType_COPY_COMPLETED,
+	responses = append(responses, &vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type: binlogdata.VEventType_COPY_COMPLETED,
+				},
 			},
 		},
 	})
 
-	responses = append(responses, &vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type:     binlogdata.VEventType_VGTID,
-				Keyspace: keyspace,
-				Shard:    shard,
-				Vgtid: &binlogdata.VGtid{
-					ShardGtids: []*binlogdata.ShardGtid{
-						{
-							Keyspace: keyspace,
-							Shard:    shard,
-							Gtid:     nextSyncVGtidPosition,
+	responses = append(responses, &vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type:     binlogdata.VEventType_VGTID,
+					Keyspace: keyspace,
+					Shard:    shard,
+					Vgtid: &binlogdata.VGtid{
+						ShardGtids: []*binlogdata.ShardGtid{
+							{
+								Keyspace: keyspace,
+								Shard:    shard,
+								Gtid:     nextSyncVGtidPosition,
+							},
 						},
 					},
 				},
@@ -1729,18 +1797,20 @@ func TestRead_FullSync_CanStopSyncEqualToStopPosition(t *testing.T) {
 	})
 
 	getCurrentVGtidClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			// First sync to get stop position
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     stopVGtidPosition,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     stopVGtidPosition,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},
@@ -1829,57 +1899,59 @@ func TestRead_FullSync_CopyCatchupLoop(t *testing.T) {
 	table := "customers"
 	database := "connect-test"
 
-	responses := []*vtgate.VStreamResponse{
+	responses := []*vstreamResponse{
 		{
-			Events: []*binlogdata.VEvent{
-				{
-					Type:     binlogdata.VEventType_BEGIN,
-					Keyspace: keyspace,
-					Shard:    shard,
-				},
-				{
-					Type:     binlogdata.VEventType_VGTID,
-					Keyspace: keyspace,
-					Shard:    shard,
-					Vgtid: &binlogdata.VGtid{
-						ShardGtids: []*binlogdata.ShardGtid{
-							{
-								Keyspace: keyspace,
-								Shard:    shard,
-								Gtid:     stopVGtidPosition,
+			response: &vtgate.VStreamResponse{
+				Events: []*binlogdata.VEvent{
+					{
+						Type:     binlogdata.VEventType_BEGIN,
+						Keyspace: keyspace,
+						Shard:    shard,
+					},
+					{
+						Type:     binlogdata.VEventType_VGTID,
+						Keyspace: keyspace,
+						Shard:    shard,
+						Vgtid: &binlogdata.VGtid{
+							ShardGtids: []*binlogdata.ShardGtid{
+								{
+									Keyspace: keyspace,
+									Shard:    shard,
+									Gtid:     stopVGtidPosition,
+								},
 							},
 						},
 					},
-				},
-				{
-					Type:     binlogdata.VEventType_COMMIT,
-					Keyspace: keyspace,
-					Shard:    shard,
-				},
-				{
-					Type: binlogdata.VEventType_FIELD,
-					FieldEvent: &binlogdata.FieldEvent{
-						TableName: table,
-						Fields: []*query.Field{
-							{
-								Name:         "id",
-								Type:         query.Type_INT64,
-								Table:        table,
-								OrgTable:     table,
-								Database:     database,
-								ColumnLength: 20,
-								Charset:      63,
-								ColumnType:   "bigint",
-							},
-							{
-								Name:         "product",
-								Type:         query.Type_VARCHAR,
-								Table:        table,
-								OrgTable:     table,
-								Database:     database,
-								ColumnLength: 1024,
-								Charset:      255,
-								ColumnType:   "varchar(256)",
+					{
+						Type:     binlogdata.VEventType_COMMIT,
+						Keyspace: keyspace,
+						Shard:    shard,
+					},
+					{
+						Type: binlogdata.VEventType_FIELD,
+						FieldEvent: &binlogdata.FieldEvent{
+							TableName: table,
+							Fields: []*query.Field{
+								{
+									Name:         "id",
+									Type:         query.Type_INT64,
+									Table:        table,
+									OrgTable:     table,
+									Database:     database,
+									ColumnLength: 20,
+									Charset:      63,
+									ColumnType:   "bigint",
+								},
+								{
+									Name:         "product",
+									Type:         query.Type_VARCHAR,
+									Table:        table,
+									OrgTable:     table,
+									Database:     database,
+									ColumnLength: 1024,
+									Charset:      255,
+									ColumnType:   "varchar(256)",
+								},
 							},
 						},
 					},
@@ -1887,12 +1959,14 @@ func TestRead_FullSync_CopyCatchupLoop(t *testing.T) {
 			},
 		},
 	}
-	copyPhase1 := vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type:     binlogdata.VEventType_BEGIN,
-				Keyspace: keyspace,
-				Shard:    shard,
+	copyPhase1 := vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type:     binlogdata.VEventType_BEGIN,
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
 			},
 		},
 	}
@@ -1910,41 +1984,43 @@ func TestRead_FullSync_CopyCatchupLoop(t *testing.T) {
 				},
 			},
 		}
-		copyPhase1.Events = append(copyPhase1.Events, &event)
+		copyPhase1.response.Events = append(copyPhase1.response.Events, &event)
 	}
 
 	responses = append(responses, &copyPhase1)
 
-	catchupPhase1 := vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type:     binlogdata.VEventType_BEGIN,
-				Keyspace: "sharded",
-				Shard:    "-80",
-			},
-			{
-				Type: binlogdata.VEventType_ROW,
-				RowEvent: &binlogdata.RowEvent{
-					TableName: "sharded.t1",
-					RowChanges: []*binlogdata.RowChange{
-						{
-							After: &query.Row{
-								Values: []byte(fmt.Sprintf("%v,keyboard", 9)),
+	catchupPhase1 := vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type:     binlogdata.VEventType_BEGIN,
+					Keyspace: "sharded",
+					Shard:    "-80",
+				},
+				{
+					Type: binlogdata.VEventType_ROW,
+					RowEvent: &binlogdata.RowEvent{
+						TableName: "sharded.t1",
+						RowChanges: []*binlogdata.RowChange{
+							{
+								After: &query.Row{
+									Values: []byte(fmt.Sprintf("%v,keyboard", 9)),
+								},
 							},
 						},
 					},
 				},
-			},
-			{
-				Type:     binlogdata.VEventType_VGTID,
-				Keyspace: keyspace,
-				Shard:    shard,
-				Vgtid: &binlogdata.VGtid{
-					ShardGtids: []*binlogdata.ShardGtid{
-						{
-							Keyspace: keyspace,
-							Shard:    shard,
-							Gtid:     fmt.Sprintf("MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", numRows),
+				{
+					Type:     binlogdata.VEventType_VGTID,
+					Keyspace: keyspace,
+					Shard:    shard,
+					Vgtid: &binlogdata.VGtid{
+						ShardGtids: []*binlogdata.ShardGtid{
+							{
+								Keyspace: keyspace,
+								Shard:    shard,
+								Gtid:     fmt.Sprintf("MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", numRows),
+							},
 						},
 					},
 				},
@@ -1954,12 +2030,14 @@ func TestRead_FullSync_CopyCatchupLoop(t *testing.T) {
 
 	responses = append(responses, &catchupPhase1)
 
-	copyPhase2 := vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type:     binlogdata.VEventType_BEGIN,
-				Keyspace: keyspace,
-				Shard:    shard,
+	copyPhase2 := vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type:     binlogdata.VEventType_BEGIN,
+					Keyspace: keyspace,
+					Shard:    shard,
+				},
 			},
 		},
 	}
@@ -1977,41 +2055,43 @@ func TestRead_FullSync_CopyCatchupLoop(t *testing.T) {
 				},
 			},
 		}
-		copyPhase2.Events = append(copyPhase2.Events, &event)
+		copyPhase2.response.Events = append(copyPhase2.response.Events, &event)
 	}
 
 	responses = append(responses, &copyPhase2)
 
-	catchupPhase2 := vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type:     binlogdata.VEventType_BEGIN,
-				Keyspace: "sharded",
-				Shard:    "-80",
-			},
-			{
-				Type: binlogdata.VEventType_ROW,
-				RowEvent: &binlogdata.RowEvent{
-					TableName: "sharded.t1",
-					RowChanges: []*binlogdata.RowChange{
-						{
-							After: &query.Row{
-								Values: []byte(fmt.Sprintf("%v,keyboard", numRows+11)),
+	catchupPhase2 := vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type:     binlogdata.VEventType_BEGIN,
+					Keyspace: "sharded",
+					Shard:    "-80",
+				},
+				{
+					Type: binlogdata.VEventType_ROW,
+					RowEvent: &binlogdata.RowEvent{
+						TableName: "sharded.t1",
+						RowChanges: []*binlogdata.RowChange{
+							{
+								After: &query.Row{
+									Values: []byte(fmt.Sprintf("%v,keyboard", numRows+11)),
+								},
 							},
 						},
 					},
 				},
-			},
-			{
-				Type:     binlogdata.VEventType_VGTID,
-				Keyspace: keyspace,
-				Shard:    shard,
-				Vgtid: &binlogdata.VGtid{
-					ShardGtids: []*binlogdata.ShardGtid{
-						{
-							Keyspace: keyspace,
-							Shard:    shard,
-							Gtid:     fmt.Sprintf("MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", 10),
+				{
+					Type:     binlogdata.VEventType_VGTID,
+					Keyspace: keyspace,
+					Shard:    shard,
+					Vgtid: &binlogdata.VGtid{
+						ShardGtids: []*binlogdata.ShardGtid{
+							{
+								Keyspace: keyspace,
+								Shard:    shard,
+								Gtid:     fmt.Sprintf("MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-%v", 10),
+							},
 						},
 					},
 				},
@@ -2021,26 +2101,30 @@ func TestRead_FullSync_CopyCatchupLoop(t *testing.T) {
 
 	responses = append(responses, &catchupPhase2)
 
-	responses = append(responses, &vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type: binlogdata.VEventType_COPY_COMPLETED,
+	responses = append(responses, &vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type: binlogdata.VEventType_COPY_COMPLETED,
+				},
 			},
 		},
 	})
 
-	responses = append(responses, &vtgate.VStreamResponse{
-		Events: []*binlogdata.VEvent{
-			{
-				Type:     binlogdata.VEventType_VGTID,
-				Keyspace: keyspace,
-				Shard:    shard,
-				Vgtid: &binlogdata.VGtid{
-					ShardGtids: []*binlogdata.ShardGtid{
-						{
-							Keyspace: keyspace,
-							Shard:    shard,
-							Gtid:     nextSyncVGtidPosition,
+	responses = append(responses, &vstreamResponse{
+		response: &vtgate.VStreamResponse{
+			Events: []*binlogdata.VEvent{
+				{
+					Type:     binlogdata.VEventType_VGTID,
+					Keyspace: keyspace,
+					Shard:    shard,
+					Vgtid: &binlogdata.VGtid{
+						ShardGtids: []*binlogdata.ShardGtid{
+							{
+								Keyspace: keyspace,
+								Shard:    shard,
+								Gtid:     nextSyncVGtidPosition,
+							},
 						},
 					},
 				},
@@ -2049,18 +2133,20 @@ func TestRead_FullSync_CopyCatchupLoop(t *testing.T) {
 	})
 
 	getCurrentVGtidClient := &vtgateVStreamClientMock{
-		vstreamResponses: []*vtgate.VStreamResponse{
+		vstreamResponses: []*vstreamResponse{
 			// First sync to get stop position
 			{
-				Events: []*binlogdata.VEvent{
-					{
-						Type: binlogdata.VEventType_VGTID,
-						Vgtid: &binlogdata.VGtid{
-							ShardGtids: []*binlogdata.ShardGtid{
-								{
-									Shard:    shard,
-									Gtid:     stopVGtidPosition,
-									Keyspace: keyspace,
+				response: &vtgate.VStreamResponse{
+					Events: []*binlogdata.VEvent{
+						{
+							Type: binlogdata.VEventType_VGTID,
+							Vgtid: &binlogdata.VGtid{
+								ShardGtids: []*binlogdata.ShardGtid{
+									{
+										Shard:    shard,
+										Gtid:     stopVGtidPosition,
+										Keyspace: keyspace,
+									},
 								},
 							},
 						},

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	github.com/spf13/viper v1.15.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect
-	github.com/twitchtv/twirp v8.1.3+incompatible // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	go.uber.org/atomic v1.10.0 // indirect
@@ -78,7 +77,6 @@ require (
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117 // indirect
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1 // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.47.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,6 @@ github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNG
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
-github.com/twitchtv/twirp v8.1.3+incompatible h1:+F4TdErPgSUbMZMwp13Q/KgDVuI7HJXP61mNV3/7iuU=
-github.com/twitchtv/twirp v8.1.3+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
@@ -772,8 +770,6 @@ google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA5
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.65.0 h1:bs/cUb4lp1G5iImFFd3u5ixQzweKizoZJAwBNLR42lc=
 google.golang.org/grpc v1.65.0/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1 h1:F29+wU6Ee6qgu9TddPgooOdaqsxTMunOoj8KA5yuS5A=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1/go.mod h1:5KF+wpkbTSbGcR9zteSqZV6fqFOWBl4Yde8En8MryZA=
 google.golang.org/grpc/examples v0.0.0-20210430044426-28078834f35b h1:D/GTYPo6I1oEo08Bfpuj3xl5XE+UGHj7//5fVyKxhsQ=
 google.golang.org/grpc/examples v0.0.0-20210430044426-28078834f35b/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=


### PR DESCRIPTION
This PR makes a few improvements:
- Adds a configurable `max retries` field. 
    - Context: previously, syncs that errored on "context deadline exceeded" could retry indefinitely
- Increases read timeout to 5 minutes
    - Context: high traffic/load DBs reach the old timeout of 1 minute often. 5 minutes is more reasonable
- Renames some vars and methods to be more accurate
- Updates mock testing to allow mocking errored responses from VStream 
- Updates tests to verify LastPK passed when full copy, and no LastPK passed when incremental copy