### PR TITLE
Convert MySQL datetime string to ISO8601

### DIFF
--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -2598,7 +2598,7 @@ func TestRead_FullSync_MaxRetries(t *testing.T) {
 	assert.Equal(t, 4, vsc.vstreamFnInvokedCount)
 
 	logLines := tal.logMessages[LOGLEVEL_INFO]
-	assert.Equal(t, strings.TrimSpace(fmt.Sprintf("[connect-test:primary:customers shard : -] %v records synced after 3 syncs. Got error [DeadlineExceeded], returning with cursor [shard:\"-\"  keyspace:\"connect-test\"  position:\"MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-10\"  last_known_pk:{fields:{name:\"id\"  type:INT64  charset:63  flags:53251}  rows:{lengths:4  values:\"30\"}}] after gRPC error", 30)), strings.TrimSpace(logLines[len(logLines)-1]))
+	assert.Equal(t, strings.ReplaceAll(fmt.Sprintf("[connect-test:primary:customers shard : -] %v records synced after 3 syncs. Got error [DeadlineExceeded], returning with cursor [shard:\"-\"  keyspace:\"connect-test\"  position:\"MySQL56/e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-10\"  last_known_pk:{fields:{name:\"id\"  type:INT64  charset:63  flags:53251}  rows:{lengths:4  values:\"30\"}}] after gRPC error", 30), " ", ""), strings.ReplaceAll(logLines[len(logLines)-1], " ", ""))
 	records := tal.records["connect-test.customers"]
 	assert.Equal(t, 30, len(records))
 }

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -188,17 +188,20 @@ func formatISO8601(mysqlType string, value sqltypes.Value) sqltypes.Value {
 	parsedDatetime := value.ToString()
 
 	var formatString string
+	var layout string
 	if mysqlType == "date" {
 		formatString = "2006-01-02"
+		layout = time.DateOnly
 	} else {
 		formatString = "2006-01-02 15:04:05"
+		layout = time.RFC3339
 	}
 	mysqlTime, err := time.Parse(formatString, parsedDatetime)
 	if err != nil {
 		// fallback to default value if datetime is not parseable
 		return value
 	}
-	iso8601Datetime := mysqlTime.Format(time.RFC3339)
+	iso8601Datetime := mysqlTime.Format(layout)
 	formattedValue, _ := sqltypes.NewValue(value.Type(), []byte(iso8601Datetime))
 	return formattedValue
 }

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -156,12 +156,13 @@ func QueryResultToRecords(qr *sqltypes.Result) []map[string]interface{} {
 // After the initial COPY phase, enum and set values may appear as an index instead of a value.
 // For example, a value might look like a "1" instead of "apple" in an enum('apple','banana','orange') column)
 func parseValue(val sqltypes.Value, columnType string, queryColumnType query.Type) sqltypes.Value {
-	if queryColumnType == query.Type_DATETIME || queryColumnType == query.Type_DATE || queryColumnType == query.Type_TIME {
+	switch queryColumnType {
+	case query.Type_DATETIME, query.Type_DATE, query.Type_TIME:
 		return formatISO8601(queryColumnType, val)
-	} else if queryColumnType == query.Type_ENUM {
+	case query.Type_ENUM:
 		values := parseEnumOrSetValues(columnType)
 		return mapEnumValue(val, values)
-	} else if queryColumnType == query.Type_SET {
+	case query.Type_SET:
 		values := parseEnumOrSetValues(columnType)
 		return mapSetValue(val, values)
 	}

--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -108,3 +108,29 @@ func TestCanMapEnumAndSetValues(t *testing.T) {
 	assert.Equal(t, "active", secondRow["status"].(sqltypes.Value).ToString())
 	assert.Equal(t, "San Francisco,Oakland", secondRow["locations"].(sqltypes.Value).ToString())
 }
+
+func TestCanFormatISO8601Values(t *testing.T) {
+	datetimeValue, err := sqltypes.NewValue(query.Type_DATETIME, []byte("2025-02-14 08:08:08"))
+	assert.NoError(t, err)
+	dateValue, err := sqltypes.NewValue(query.Type_DATE, []byte("2025-02-14"))
+	assert.NoError(t, err)
+	timestampValue, err := sqltypes.NewValue(query.Type_TIMESTAMP, []byte("2025-02-14 08:08:08"))
+	assert.NoError(t, err)
+	input := sqltypes.Result{
+		Fields: []*query.Field{
+			{Name: "datetime_created_at", Type: sqltypes.Datetime, ColumnType: "datetime"},
+			{Name: "date_created_at", Type: sqltypes.Date, ColumnType: "date"},
+			{Name: "timestamp_created_at", Type: sqltypes.Set, ColumnType: "timestamp"},
+		},
+		Rows: [][]sqltypes.Value{
+			{datetimeValue, dateValue, timestampValue},
+		},
+	}
+
+	output := QueryResultToRecords(&input)
+	assert.Equal(t, 1, len(output))
+	row := output[0]
+	assert.Equal(t, "2025-02-14T08:08:08Z", row["datetime_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "2025-02-14T00:00:00Z", row["date_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "2025-02-14T08:08:08Z", row["timestamp_created_at"].(sqltypes.Value).ToString())
+}

--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -120,7 +120,7 @@ func TestCanFormatISO8601Values(t *testing.T) {
 		Fields: []*query.Field{
 			{Name: "datetime_created_at", Type: sqltypes.Datetime, ColumnType: "datetime"},
 			{Name: "date_created_at", Type: sqltypes.Date, ColumnType: "date"},
-			{Name: "timestamp_created_at", Type: sqltypes.Set, ColumnType: "timestamp"},
+			{Name: "timestamp_created_at", Type: sqltypes.Time, ColumnType: "timestamp"},
 		},
 		Rows: [][]sqltypes.Value{
 			{datetimeValue, dateValue, timestampValue},

--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -131,6 +131,6 @@ func TestCanFormatISO8601Values(t *testing.T) {
 	assert.Equal(t, 1, len(output))
 	row := output[0]
 	assert.Equal(t, "2025-02-14T08:08:08Z", row["datetime_created_at"].(sqltypes.Value).ToString())
-	assert.Equal(t, "2025-02-14T00:00:00Z", row["date_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "2025-02-14", row["date_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "2025-02-14T08:08:08Z", row["timestamp_created_at"].(sqltypes.Value).ToString())
 }


### PR DESCRIPTION
Airbyte specifies that MySQL datetime/timestamp/date strings need to be parsed into ISO8601 format. This PR does that and also adds an extra log about whether we are looking for a COPY COMPLETED event or a stop position.