### PR TITLE
Support `null` in Airbyte schema column type

### DIFF
--- a/cmd/airbyte-source/read.go
+++ b/cmd/airbyte-source/read.go
@@ -64,7 +64,7 @@ func ReadCommand(ch *Helper) *cobra.Command {
 
 			catalog, err := readCatalog(readSourceCatalogPath)
 			if err != nil {
-				ch.Logger.Error("Unable to read catalog")
+				ch.Logger.Error(fmt.Sprintf("Unable to read catalog: %+v", err))
 				os.Exit(1)
 			}
 

--- a/cmd/airbyte-source/read_test.go
+++ b/cmd/airbyte-source/read_test.go
@@ -28,7 +28,7 @@ func TestRead_StartingGtidsAndState(t *testing.T) {
 					Type: "object",
 					Properties: map[string]internal.PropertyType{
 						"id": {
-							Type:        "number",
+							Type:        []string{"number"},
 							AirbyteType: "integer",
 						},
 					},
@@ -55,7 +55,7 @@ func TestRead_StartingGtidsAndState(t *testing.T) {
 					Type: "object",
 					Properties: map[string]internal.PropertyType{
 						"id": {
-							Type:        "number",
+							Type:        []string{"number"},
 							AirbyteType: "integer",
 						},
 					},

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -362,6 +362,7 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 		JSONSchemaType        []string
 		AirbyteType           string
 		TreatTinyIntAsBoolean bool
+		IsNullable            string
 	}{
 		{
 			MysqlType:      "int(11)",
@@ -459,6 +460,12 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 			AirbyteType:    "",
 		},
 		{
+			MysqlType:      "varchar(256)",
+			JSONSchemaType: []string{"string", "null"},
+			AirbyteType:    "",
+			IsNullable:     "YES",
+		},
+		{
 			MysqlType:      "decimal(12,5)",
 			JSONSchemaType: []string{"number"},
 			AirbyteType:    "",
@@ -478,7 +485,7 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 	for _, typeTest := range tests {
 
 		t.Run(fmt.Sprintf("mysql_type_%v", typeTest.MysqlType), func(t *testing.T) {
-			p := getJsonSchemaType(typeTest.MysqlType, typeTest.TreatTinyIntAsBoolean, "NO")
+			p := getJsonSchemaType(typeTest.MysqlType, typeTest.TreatTinyIntAsBoolean, typeTest.IsNullable)
 			assert.Equal(t, typeTest.AirbyteType, p.AirbyteType)
 			assert.Equal(t, typeTest.JSONSchemaType, p.Type)
 		})

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -478,7 +478,7 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 	for _, typeTest := range tests {
 
 		t.Run(fmt.Sprintf("mysql_type_%v", typeTest.MysqlType), func(t *testing.T) {
-			p := getJsonSchemaType(typeTest.MysqlType, typeTest.TreatTinyIntAsBoolean)
+			p := getJsonSchemaType(typeTest.MysqlType, typeTest.TreatTinyIntAsBoolean, "NO")
 			assert.Equal(t, typeTest.AirbyteType, p.AirbyteType)
 			assert.Equal(t, typeTest.JSONSchemaType, p.Type)
 		})

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -359,118 +359,118 @@ func TestRead_CanPickRdonlyForShardedKeyspaces(t *testing.T) {
 func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 	var tests = []struct {
 		MysqlType             string
-		JSONSchemaType        string
+		JSONSchemaType        []string
 		AirbyteType           string
 		TreatTinyIntAsBoolean bool
 	}{
 		{
 			MysqlType:      "int(11)",
-			JSONSchemaType: "number",
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "smallint(4)",
-			JSONSchemaType: "number",
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "mediumint(8)",
-			JSONSchemaType: "number",
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:             "tinyint",
-			JSONSchemaType:        "number",
+			JSONSchemaType:        []string{"number"},
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1)",
-			JSONSchemaType:        "boolean",
+			JSONSchemaType:        []string{"boolean"},
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1) unsigned",
-			JSONSchemaType:        "boolean",
+			JSONSchemaType:        []string{"boolean"},
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1)",
-			JSONSchemaType:        "number",
+			JSONSchemaType:        []string{"number"},
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:             "tinyint(1) unsigned",
-			JSONSchemaType:        "number",
+			JSONSchemaType:        []string{"number"},
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:      "bigint(16)",
-			JSONSchemaType: "number",
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "bigint unsigned",
-			JSONSchemaType: "number",
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "bigint zerofill",
-			JSONSchemaType: "number",
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "datetime",
-			JSONSchemaType: "string",
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "datetime(6)",
-			JSONSchemaType: "string",
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "time",
-			JSONSchemaType: "string",
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "time_without_timezone",
 		},
 		{
 			MysqlType:      "time(6)",
-			JSONSchemaType: "string",
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "time_without_timezone",
 		},
 		{
 			MysqlType:      "date",
-			JSONSchemaType: "string",
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "date",
 		},
 		{
 			MysqlType:      "text",
-			JSONSchemaType: "string",
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "varchar(256)",
-			JSONSchemaType: "string",
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "decimal(12,5)",
-			JSONSchemaType: "number",
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "double",
-			JSONSchemaType: "number",
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "float(30)",
-			JSONSchemaType: "number",
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "",
 		},
 	}

--- a/cmd/internal/planetscale_edge_mysql.go
+++ b/cmd/internal/planetscale_edge_mysql.go
@@ -170,7 +170,7 @@ func (p planetScaleEdgeMySQLAccess) GetTableSchema(ctx context.Context, psc Plan
 			columnType string
 			nullable   string
 		)
-		if err = columnNamesQR.Scan(&name, &columnType); err != nil {
+		if err = columnNamesQR.Scan(&name, &columnType, &nullable); err != nil {
 			return properties, errors.Wrapf(err, "Unable to scan row for column names & types of table %v", tableName)
 		}
 

--- a/cmd/internal/planetscale_edge_mysql.go
+++ b/cmd/internal/planetscale_edge_mysql.go
@@ -157,7 +157,7 @@ func (p planetScaleEdgeMySQLAccess) GetTableSchema(ctx context.Context, psc Plan
 
 	columnNamesQR, err := p.db.QueryContext(
 		ctx,
-		"select column_name, column_type from information_schema.columns where table_name=? AND table_schema=?;",
+		"select column_name, column_type, is_nullable from information_schema.columns where table_name=? AND table_schema=?;",
 		tableName, psc.Database,
 	)
 	if err != nil {
@@ -168,12 +168,13 @@ func (p planetScaleEdgeMySQLAccess) GetTableSchema(ctx context.Context, psc Plan
 		var (
 			name       string
 			columnType string
+			nullable   string
 		)
 		if err = columnNamesQR.Scan(&name, &columnType); err != nil {
 			return properties, errors.Wrapf(err, "Unable to scan row for column names & types of table %v", tableName)
 		}
 
-		properties[name] = getJsonSchemaType(columnType, !psc.Options.DoNotTreatTinyIntAsBoolean)
+		properties[name] = getJsonSchemaType(columnType, !psc.Options.DoNotTreatTinyIntAsBoolean, nullable)
 	}
 
 	if err := columnNamesQR.Err(); err != nil {

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -54,9 +54,9 @@ const (
 )
 
 type PropertyType struct {
-	Type         string `json:"type"`
-	CustomFormat string `json:"format,omitempty"`
-	AirbyteType  string `json:"airbyte_type,omitempty"`
+	Type         []string `json:"type"`
+	CustomFormat string   `json:"format,omitempty"`
+	AirbyteType  string   `json:"airbyte_type,omitempty"`
 }
 
 type StreamSchema struct {


### PR DESCRIPTION
This PR modifies the returned property type to support nullable columns:
```
"type": ["string", "null"]
```

According to https://docs.airbyte.com/understanding-airbyte/supported-data-types/#unions this would be the syntax.