### PR TITLE
Nullable columns: output in `oneOf` JSON schema format

### DIFF
--- a/cmd/airbyte-source/read_test.go
+++ b/cmd/airbyte-source/read_test.go
@@ -20,6 +20,9 @@ func TestRead_StartingGtidsAndState(t *testing.T) {
 		Password:      "pscale_password",
 		StartingGtids: "{\"sharded\": {\"-80\": \"MySQL56/MyGTID:1-3\"}}",
 	}
+
+	numberType := "number"
+
 	streams := []internal.ConfiguredStream{
 		{
 			Stream: internal.Stream{
@@ -28,7 +31,7 @@ func TestRead_StartingGtidsAndState(t *testing.T) {
 					Type: "object",
 					Properties: map[string]internal.PropertyType{
 						"id": {
-							Type:        []string{"number"},
+							Type:        &numberType,
 							AirbyteType: "integer",
 						},
 					},
@@ -55,7 +58,7 @@ func TestRead_StartingGtidsAndState(t *testing.T) {
 					Type: "object",
 					Properties: map[string]internal.PropertyType{
 						"id": {
-							Type:        []string{"number"},
+							Type:        &numberType,
 							AirbyteType: "integer",
 						},
 					},

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -135,31 +135,56 @@ func (p PlanetScaleEdgeDatabase) getStreamForTable(ctx context.Context, psc Plan
 func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool, nullable string) PropertyType {
 	// Support custom airbyte types documented here :
 	// https://docs.airbyte.com/understanding-airbyte/supported-data-types/#the-types
-	var propertyType PropertyType
+	var (
+		jsonSchemaType string
+		customFormat   string
+		airbyteType    string
+		oneOf          []OneOfType
+	)
 
 	switch {
 	case strings.HasPrefix(mysqlType, "tinyint(1)"):
 		if treatTinyIntAsBoolean {
-			propertyType = PropertyType{Type: []string{"boolean"}}
+			jsonSchemaType = "boolean"
 		} else {
-			propertyType = PropertyType{Type: []string{"number"}, AirbyteType: "integer"}
+			jsonSchemaType = "number"
+			airbyteType = "integer"
 		}
 	case strings.HasPrefix(mysqlType, "int"), strings.HasPrefix(mysqlType, "smallint"), strings.HasPrefix(mysqlType, "mediumint"), strings.HasPrefix(mysqlType, "bigint"), strings.HasPrefix(mysqlType, "tinyint"):
-		propertyType = PropertyType{Type: []string{"number"}, AirbyteType: "integer"}
+		jsonSchemaType = "number"
+		airbyteType = "integer"
 	case strings.HasPrefix(mysqlType, "decimal"), strings.HasPrefix(mysqlType, "double"), strings.HasPrefix(mysqlType, "float"):
-		propertyType = PropertyType{Type: []string{"number"}}
+		jsonSchemaType = "number"
 	case strings.HasPrefix(mysqlType, "datetime"), strings.HasPrefix(mysqlType, "timestamp"):
-		propertyType = PropertyType{Type: []string{"string"}, CustomFormat: "date-time", AirbyteType: "timestamp_without_timezone"}
+		jsonSchemaType = "string"
+		customFormat = "date-time"
+		airbyteType = "timestamp_without_timezone"
 	case strings.HasPrefix(mysqlType, "date"):
-		propertyType = PropertyType{Type: []string{"string"}, CustomFormat: "date", AirbyteType: "date"}
+		jsonSchemaType = "string"
+		customFormat = "date"
+		airbyteType = "date"
 	case strings.HasPrefix(mysqlType, "time"):
-		propertyType = PropertyType{Type: []string{"string"}, CustomFormat: "time", AirbyteType: "time_without_timezone"}
+		jsonSchemaType = "string"
+		customFormat = "time"
+		airbyteType = "time_without_timezone"
 	default:
-		propertyType = PropertyType{Type: []string{"string"}}
+		jsonSchemaType = "string"
+	}
+
+	propertyType := PropertyType{
+		Type:         &jsonSchemaType,
+		CustomFormat: customFormat,
+		AirbyteType:  airbyteType,
 	}
 
 	if strings.ToLower(nullable) == "yes" {
-		propertyType.Type = append(propertyType.Type, "null")
+		oneOf = []OneOfType{
+			{Type: jsonSchemaType},
+			{Type: "null"},
+		}
+
+		propertyType.Type = nil
+		propertyType.OneOf = oneOf
 	}
 
 	return propertyType

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -357,127 +357,135 @@ func TestRead_CanPickRdonlyForShardedKeyspaces(t *testing.T) {
 }
 
 func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
+	numberType := "number"
+	booleanType := "boolean"
+	stringType := "string"
+
 	var tests = []struct {
 		MysqlType             string
-		JSONSchemaType        []string
+		JSONSchemaType        *string
+		OneOf                 []OneOfType
 		AirbyteType           string
 		TreatTinyIntAsBoolean bool
 		IsNullable            string
 	}{
 		{
 			MysqlType:      "int(11)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "smallint(4)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "mediumint(8)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:             "tinyint",
-			JSONSchemaType:        []string{"number"},
+			JSONSchemaType:        &numberType,
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1)",
-			JSONSchemaType:        []string{"boolean"},
+			JSONSchemaType:        &booleanType,
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1) unsigned",
-			JSONSchemaType:        []string{"boolean"},
+			JSONSchemaType:        &booleanType,
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1)",
-			JSONSchemaType:        []string{"number"},
+			JSONSchemaType:        &numberType,
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:             "tinyint(1) unsigned",
-			JSONSchemaType:        []string{"number"},
+			JSONSchemaType:        &numberType,
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:      "bigint(16)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "bigint unsigned",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "bigint zerofill",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "datetime",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "datetime(6)",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "time",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "time_without_timezone",
 		},
 		{
 			MysqlType:      "time(6)",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "time_without_timezone",
 		},
 		{
 			MysqlType:      "date",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "date",
 		},
 		{
 			MysqlType:      "text",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "varchar(256)",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "",
 		},
 		{
-			MysqlType:      "varchar(256)",
-			JSONSchemaType: []string{"string", "null"},
-			AirbyteType:    "",
-			IsNullable:     "YES",
+			MysqlType:   "varchar(256)",
+			AirbyteType: "",
+			IsNullable:  "YES",
+			OneOf: []OneOfType{
+				{Type: "string"},
+				{Type: "null"},
+			},
 		},
 		{
 			MysqlType:      "decimal(12,5)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "double",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "float(30)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "",
 		},
 	}
@@ -488,6 +496,7 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 			p := getJsonSchemaType(typeTest.MysqlType, typeTest.TreatTinyIntAsBoolean, typeTest.IsNullable)
 			assert.Equal(t, typeTest.AirbyteType, p.AirbyteType)
 			assert.Equal(t, typeTest.JSONSchemaType, p.Type)
+			assert.Equal(t, typeTest.OneOf, p.OneOf)
 		})
 	}
 }

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -54,9 +54,14 @@ const (
 )
 
 type PropertyType struct {
-	Type         []string `json:"type"`
-	CustomFormat string   `json:"format,omitempty"`
-	AirbyteType  string   `json:"airbyte_type,omitempty"`
+	Type         *string     `json:"type,omitempty"`
+	CustomFormat string      `json:"format,omitempty"`
+	AirbyteType  string      `json:"airbyte_type,omitempty"`
+	OneOf        []OneOfType `json:"oneOf,omitempty"`
+}
+
+type OneOfType struct {
+	Type string `json:"type"`
 }
 
 type StreamSchema struct {


### PR DESCRIPTION
This is a continuation of the last PR to support nullable columns. Instead of `"type": ["string", "null"]`, output in json schema format instead, using `oneOf` terminology:
```
"oneOf": [
  {"type": "string"},
  {"type": "null"}
]
```