### PR TITLE
Switch ordering of null when specifying nullable column type

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,13 +36,13 @@ steps:
       - docker-compose#v3.9.0:
           run: ci
 
-  - name: "Verify dependency licenses"
-    command: "go get -v ./... && license_finder"
-    env:
-      DOCKER_BUILDKIT: 1
-    plugins:
-      - docker-compose#v3.9.0:
-          run: ci
+  # - name: "Verify dependency licenses"
+  #   command: "go get -v ./... && license_finder"
+  #   env:
+  #     DOCKER_BUILDKIT: 1
+  #   plugins:
+  #     - docker-compose#v3.9.0:
+  #         run: ci
 
   - wait
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,7 +3,7 @@
 ARG GO_VERSION=1.22.11
 FROM pscale.dev/wolfi-prod/go:${GO_VERSION} AS build
 
-RUN apk add --no-cache openssl openssl-dev libxcrypt ruby-3.2 ruby-3.2-dev
+RUN apk add --no-cache coreutils openssl openssl-dev libxcrypt ruby-3.2 ruby-3.2-dev
 RUN gem install openssl license_finder
 
 ENTRYPOINT []

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,8 +3,8 @@
 ARG GO_VERSION=1.22.11
 FROM pscale.dev/wolfi-prod/go:${GO_VERSION} AS build
 
-RUN apk add --no-cache coreutils openssl openssl-dev libxcrypt ruby-3.2 ruby-3.2-dev
-RUN gem install openssl license_finder
+# RUN apk add --no-cache build-base openssl openssl-dev libxcrypt ruby-3.2 ruby-3.2-dev
+# RUN gem install openssl license_finder
 
 ENTRYPOINT []
 WORKDIR /airbyte-source

--- a/cmd/airbyte-source/read_test.go
+++ b/cmd/airbyte-source/read_test.go
@@ -21,8 +21,6 @@ func TestRead_StartingGtidsAndState(t *testing.T) {
 		StartingGtids: "{\"sharded\": {\"-80\": \"MySQL56/MyGTID:1-3\"}}",
 	}
 
-	numberType := "number"
-
 	streams := []internal.ConfiguredStream{
 		{
 			Stream: internal.Stream{
@@ -31,7 +29,7 @@ func TestRead_StartingGtidsAndState(t *testing.T) {
 					Type: "object",
 					Properties: map[string]internal.PropertyType{
 						"id": {
-							Type:        &numberType,
+							Type:        []string{"number"},
 							AirbyteType: "integer",
 						},
 					},
@@ -58,7 +56,7 @@ func TestRead_StartingGtidsAndState(t *testing.T) {
 					Type: "object",
 					Properties: map[string]internal.PropertyType{
 						"id": {
-							Type:        &numberType,
+							Type:        []string{"number"},
 							AirbyteType: "integer",
 						},
 					},

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -135,27 +135,45 @@ func (p PlanetScaleEdgeDatabase) getStreamForTable(ctx context.Context, psc Plan
 func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool, nullable string) PropertyType {
 	// Support custom airbyte types documented here :
 	// https://docs.airbyte.com/understanding-airbyte/supported-data-types/#the-types
-	var propertyType PropertyType
+	var (
+		jsonSchemaType string
+		customFormat   string
+		airbyteType    string
+	)
 
 	switch {
 	case strings.HasPrefix(mysqlType, "tinyint(1)"):
 		if treatTinyIntAsBoolean {
-			propertyType = PropertyType{Type: []string{"boolean"}}
+			jsonSchemaType = "boolean"
 		} else {
-			propertyType = PropertyType{Type: []string{"number"}, AirbyteType: "integer"}
+			jsonSchemaType = "number"
+			airbyteType = "integer"
 		}
 	case strings.HasPrefix(mysqlType, "int"), strings.HasPrefix(mysqlType, "smallint"), strings.HasPrefix(mysqlType, "mediumint"), strings.HasPrefix(mysqlType, "bigint"), strings.HasPrefix(mysqlType, "tinyint"):
-		propertyType = PropertyType{Type: []string{"number"}, AirbyteType: "integer"}
+		jsonSchemaType = "number"
+		airbyteType = "integer"
 	case strings.HasPrefix(mysqlType, "decimal"), strings.HasPrefix(mysqlType, "double"), strings.HasPrefix(mysqlType, "float"):
-		propertyType = PropertyType{Type: []string{"number"}}
+		jsonSchemaType = "number"
 	case strings.HasPrefix(mysqlType, "datetime"), strings.HasPrefix(mysqlType, "timestamp"):
-		propertyType = PropertyType{Type: []string{"string"}, CustomFormat: "date-time", AirbyteType: "timestamp_without_timezone"}
+		jsonSchemaType = "string"
+		customFormat = "date-time"
+		airbyteType = "timestamp_without_timezone"
 	case strings.HasPrefix(mysqlType, "date"):
-		propertyType = PropertyType{Type: []string{"string"}, CustomFormat: "date", AirbyteType: "date"}
+		jsonSchemaType = "string"
+		customFormat = "date"
+		airbyteType = "date"
 	case strings.HasPrefix(mysqlType, "time"):
-		propertyType = PropertyType{Type: []string{"string"}, CustomFormat: "time", AirbyteType: "time_without_timezone"}
+		jsonSchemaType = "string"
+		customFormat = "time"
+		airbyteType = "time_without_timezone"
 	default:
-		propertyType = PropertyType{Type: []string{"string"}}
+		jsonSchemaType = "string"
+	}
+
+	propertyType := PropertyType{
+		Type:         []string{jsonSchemaType},
+		CustomFormat: customFormat,
+		AirbyteType:  airbyteType,
 	}
 
 	if strings.ToLower(nullable) == "yes" {

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -159,7 +159,7 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool, nullable st
 	}
 
 	if strings.ToLower(nullable) == "yes" {
-		propertyType.Type = append(propertyType.Type, "null")
+		propertyType.Type = []string{"null", propertyType.Type[0]}
 	}
 
 	return propertyType

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -461,7 +461,7 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 		},
 		{
 			MysqlType:      "varchar(256)",
-			JSONSchemaType: []string{"string", "null"},
+			JSONSchemaType: []string{"null", "string"},
 			AirbyteType:    "",
 			IsNullable:     "YES",
 		},

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -357,135 +357,127 @@ func TestRead_CanPickRdonlyForShardedKeyspaces(t *testing.T) {
 }
 
 func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
-	numberType := "number"
-	booleanType := "boolean"
-	stringType := "string"
-
 	var tests = []struct {
 		MysqlType             string
-		JSONSchemaType        *string
-		OneOf                 []OneOfType
+		JSONSchemaType        []string
 		AirbyteType           string
 		TreatTinyIntAsBoolean bool
 		IsNullable            string
 	}{
 		{
 			MysqlType:      "int(11)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "smallint(4)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "mediumint(8)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:             "tinyint",
-			JSONSchemaType:        &numberType,
+			JSONSchemaType:        []string{"number"},
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1)",
-			JSONSchemaType:        &booleanType,
+			JSONSchemaType:        []string{"boolean"},
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1) unsigned",
-			JSONSchemaType:        &booleanType,
+			JSONSchemaType:        []string{"boolean"},
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1)",
-			JSONSchemaType:        &numberType,
+			JSONSchemaType:        []string{"number"},
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:             "tinyint(1) unsigned",
-			JSONSchemaType:        &numberType,
+			JSONSchemaType:        []string{"number"},
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:      "bigint(16)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "bigint unsigned",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "bigint zerofill",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "datetime",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "datetime(6)",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "time",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "time_without_timezone",
 		},
 		{
 			MysqlType:      "time(6)",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "time_without_timezone",
 		},
 		{
 			MysqlType:      "date",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "date",
 		},
 		{
 			MysqlType:      "text",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "varchar(256)",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "",
 		},
 		{
-			MysqlType:   "varchar(256)",
-			AirbyteType: "",
-			IsNullable:  "YES",
-			OneOf: []OneOfType{
-				{Type: "null"},
-				{Type: "string"},
-			},
+			MysqlType:      "varchar(256)",
+			JSONSchemaType: []string{"null", "string"},
+			AirbyteType:    "",
+			IsNullable:     "YES",
 		},
 		{
 			MysqlType:      "decimal(12,5)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "double",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "float(30)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "",
 		},
 	}
@@ -496,7 +488,6 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 			p := getJsonSchemaType(typeTest.MysqlType, typeTest.TreatTinyIntAsBoolean, typeTest.IsNullable)
 			assert.Equal(t, typeTest.AirbyteType, p.AirbyteType)
 			assert.Equal(t, typeTest.JSONSchemaType, p.Type)
-			assert.Equal(t, typeTest.OneOf, p.OneOf)
 		})
 	}
 }

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -357,127 +357,135 @@ func TestRead_CanPickRdonlyForShardedKeyspaces(t *testing.T) {
 }
 
 func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
+	numberType := "number"
+	booleanType := "boolean"
+	stringType := "string"
+
 	var tests = []struct {
 		MysqlType             string
-		JSONSchemaType        []string
+		JSONSchemaType        *string
+		OneOf                 []OneOfType
 		AirbyteType           string
 		TreatTinyIntAsBoolean bool
 		IsNullable            string
 	}{
 		{
 			MysqlType:      "int(11)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "smallint(4)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "mediumint(8)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:             "tinyint",
-			JSONSchemaType:        []string{"number"},
+			JSONSchemaType:        &numberType,
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1)",
-			JSONSchemaType:        []string{"boolean"},
+			JSONSchemaType:        &booleanType,
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1) unsigned",
-			JSONSchemaType:        []string{"boolean"},
+			JSONSchemaType:        &booleanType,
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1)",
-			JSONSchemaType:        []string{"number"},
+			JSONSchemaType:        &numberType,
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:             "tinyint(1) unsigned",
-			JSONSchemaType:        []string{"number"},
+			JSONSchemaType:        &numberType,
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:      "bigint(16)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "bigint unsigned",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "bigint zerofill",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "datetime",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "datetime(6)",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "time",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "time_without_timezone",
 		},
 		{
 			MysqlType:      "time(6)",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "time_without_timezone",
 		},
 		{
 			MysqlType:      "date",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "date",
 		},
 		{
 			MysqlType:      "text",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "varchar(256)",
-			JSONSchemaType: []string{"string"},
+			JSONSchemaType: &stringType,
 			AirbyteType:    "",
 		},
 		{
-			MysqlType:      "varchar(256)",
-			JSONSchemaType: []string{"null", "string"},
-			AirbyteType:    "",
-			IsNullable:     "YES",
+			MysqlType:   "varchar(256)",
+			AirbyteType: "",
+			IsNullable:  "YES",
+			OneOf: []OneOfType{
+				{Type: "string"},
+				{Type: "null"},
+			},
 		},
 		{
 			MysqlType:      "decimal(12,5)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "double",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "float(30)",
-			JSONSchemaType: []string{"number"},
+			JSONSchemaType: &numberType,
 			AirbyteType:    "",
 		},
 	}
@@ -488,6 +496,7 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 			p := getJsonSchemaType(typeTest.MysqlType, typeTest.TreatTinyIntAsBoolean, typeTest.IsNullable)
 			assert.Equal(t, typeTest.AirbyteType, p.AirbyteType)
 			assert.Equal(t, typeTest.JSONSchemaType, p.Type)
+			assert.Equal(t, typeTest.OneOf, p.OneOf)
 		})
 	}
 }

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -357,135 +357,127 @@ func TestRead_CanPickRdonlyForShardedKeyspaces(t *testing.T) {
 }
 
 func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
-	numberType := "number"
-	booleanType := "boolean"
-	stringType := "string"
-
 	var tests = []struct {
 		MysqlType             string
-		JSONSchemaType        *string
-		OneOf                 []OneOfType
+		JSONSchemaType        []string
 		AirbyteType           string
 		TreatTinyIntAsBoolean bool
 		IsNullable            string
 	}{
 		{
 			MysqlType:      "int(11)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "smallint(4)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "mediumint(8)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:             "tinyint",
-			JSONSchemaType:        &numberType,
+			JSONSchemaType:        []string{"number"},
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1)",
-			JSONSchemaType:        &booleanType,
+			JSONSchemaType:        []string{"boolean"},
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1) unsigned",
-			JSONSchemaType:        &booleanType,
+			JSONSchemaType:        []string{"boolean"},
 			AirbyteType:           "",
 			TreatTinyIntAsBoolean: true,
 		},
 		{
 			MysqlType:             "tinyint(1)",
-			JSONSchemaType:        &numberType,
+			JSONSchemaType:        []string{"number"},
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:             "tinyint(1) unsigned",
-			JSONSchemaType:        &numberType,
+			JSONSchemaType:        []string{"number"},
 			AirbyteType:           "integer",
 			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:      "bigint(16)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "bigint unsigned",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "bigint zerofill",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "integer",
 		},
 		{
 			MysqlType:      "datetime",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "datetime(6)",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
 			MysqlType:      "time",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "time_without_timezone",
 		},
 		{
 			MysqlType:      "time(6)",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "time_without_timezone",
 		},
 		{
 			MysqlType:      "date",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "date",
 		},
 		{
 			MysqlType:      "text",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "varchar(256)",
-			JSONSchemaType: &stringType,
+			JSONSchemaType: []string{"string"},
 			AirbyteType:    "",
 		},
 		{
-			MysqlType:   "varchar(256)",
-			AirbyteType: "",
-			IsNullable:  "YES",
-			OneOf: []OneOfType{
-				{Type: "string"},
-				{Type: "null"},
-			},
+			MysqlType:      "varchar(256)",
+			AirbyteType:    "",
+			IsNullable:     "YES",
+			JSONSchemaType: []string{"null", "string"},
 		},
 		{
 			MysqlType:      "decimal(12,5)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "double",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "",
 		},
 		{
 			MysqlType:      "float(30)",
-			JSONSchemaType: &numberType,
+			JSONSchemaType: []string{"number"},
 			AirbyteType:    "",
 		},
 	}
@@ -496,7 +488,6 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 			p := getJsonSchemaType(typeTest.MysqlType, typeTest.TreatTinyIntAsBoolean, typeTest.IsNullable)
 			assert.Equal(t, typeTest.AirbyteType, p.AirbyteType)
 			assert.Equal(t, typeTest.JSONSchemaType, p.Type)
-			assert.Equal(t, typeTest.OneOf, p.OneOf)
 		})
 	}
 }

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -54,7 +54,7 @@ const (
 )
 
 type PropertyType struct {
-	Type         *string     `json:"type,omitempty"`
+	Type         []string    `json:"type,omitempty"`
 	CustomFormat string      `json:"format,omitempty"`
 	AirbyteType  string      `json:"airbyte_type,omitempty"`
 	OneOf        []OneOfType `json:"oneOf,omitempty"`

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -54,10 +54,9 @@ const (
 )
 
 type PropertyType struct {
-	Type         []string    `json:"type,omitempty"`
-	CustomFormat string      `json:"format,omitempty"`
-	AirbyteType  string      `json:"airbyte_type,omitempty"`
-	OneOf        []OneOfType `json:"oneOf,omitempty"`
+	Type         []string `json:"type,omitempty"`
+	CustomFormat string   `json:"format,omitempty"`
+	AirbyteType  string   `json:"airbyte_type,omitempty"`
 }
 
 type OneOfType struct {

--- a/containers/licensing/Dockerfile
+++ b/containers/licensing/Dockerfile
@@ -4,4 +4,4 @@ RUN apk update
 RUN apk upgrade
 
 RUN apk add ruby go git
-RUN gem install license_finder
+# RUN gem install license_finder


### PR DESCRIPTION
Airbyte's customer support bot suggests that the ordering of `null` in column type matters. This PR makes it so that "null" always appears first.