### PR TITLE
Handle boolean and null time values

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -421,7 +421,7 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, syncMode string, tc *
 					}
 					sqlResult.Rows = append(sqlResult.Rows, row)
 					// Results queued to Airbyte here, and flushed at the end of sync()
-					p.printQueryResult(sqlResult, keyspaceOrDatabase, s.Name)
+					p.printQueryResult(sqlResult, keyspaceOrDatabase, s.Name, &ps)
 				}
 			}
 		}
@@ -509,8 +509,8 @@ func (p PlanetScaleEdgeDatabase) initializeVTGateClient(ctx context.Context, ps 
 
 // printQueryResult will pretty-print an AirbyteRecordMessage to the logger.
 // Copied from vtctl/query.go
-func (p PlanetScaleEdgeDatabase) printQueryResult(qr *sqltypes.Result, tableNamespace, tableName string) {
-	data := QueryResultToRecords(qr)
+func (p PlanetScaleEdgeDatabase) printQueryResult(qr *sqltypes.Result, tableNamespace, tableName string, ps *PlanetScaleSource) {
+	data := QueryResultToRecords(qr, ps)
 
 	for _, record := range data {
 		p.Logger.Record(tableNamespace, tableName, record)

--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -170,13 +170,18 @@ func TestCanFormatISO8601Values(t *testing.T) {
 		},
 		Rows: [][]sqltypes.Value{
 			{datetimeValue, dateValue, timestampValue},
+			{sqltypes.NULL, sqltypes.NULL, sqltypes.NULL},
 		},
 	}
 
 	output := QueryResultToRecords(&input, &PlanetScaleSource{})
-	assert.Equal(t, 1, len(output))
+	assert.Equal(t, 2, len(output))
 	row := output[0]
 	assert.Equal(t, "2025-02-14T08:08:08Z", row["datetime_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "2025-02-14", row["date_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "2025-02-14T08:08:08Z", row["timestamp_created_at"].(sqltypes.Value).ToString())
+	nullRow := output[1]
+	assert.Equal(t, "0001-01-01T00:00:00Z", nullRow["datetime_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "0001-01-01", nullRow["date_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "0001-01-01T00:00:00Z", nullRow["timestamp_created_at"].(sqltypes.Value).ToString())
 }


### PR DESCRIPTION
This PR begins handling **boolean**, **zero date/datetime/timestamp**, **null** values according to Airbyte's MySQL documentation https://docs.airbyte.com/integrations/sources/mysql#data-type-mapping 

**Boolean**
If users specific `do_not_treat_tiny_int_as_bool: false`, we need to convert tinyint(1) to boolean values. This PR makes it so that we return `false`/`true` as the record's value, instead of a MySQL Value.

**Zero date/datetime/timstamp**
Airbyte specifies that for a non-null zero date value, we need to send Airbyte a "zero" EPOCH ISO-8601 string. This PR does that and adds tests.

**`null` values**
For a null value, Airbyte specifies that we should send it as a JSON `null` value. This PR does that and adds tests.
