### PR TITLE
Add microseconds and use time offset

### DIFF
--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -244,7 +244,7 @@ func formatISO8601(mysqlType query.Type, value sqltypes.Value) Value {
 		layout = time.DateOnly
 	} else {
 		formatString = "2006-01-02 15:04:05"
-		layout = time.RFC3339
+		layout = "2006-01-02T15:04:05.000000-07:00"
 	}
 
 	var (

--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -184,15 +184,15 @@ func TestCanFormatISO8601Values(t *testing.T) {
 	output := QueryResultToRecords(&input, &PlanetScaleSource{})
 	assert.Equal(t, 3, len(output))
 	row := output[0]
-	assert.Equal(t, "2025-02-14T08:08:08Z", row["datetime_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "2025-02-14T08:08:08.000000+00:00", row["datetime_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "2025-02-14", row["date_created_at"].(sqltypes.Value).ToString())
-	assert.Equal(t, "2025-02-14T08:08:08Z", row["timestamp_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "2025-02-14T08:08:08.000000+00:00", row["timestamp_created_at"].(sqltypes.Value).ToString())
 	nullRow := output[1]
 	assert.Equal(t, nil, nullRow["datetime_created_at"])
 	assert.Equal(t, nil, nullRow["date_created_at"])
 	assert.Equal(t, nil, nullRow["timestamp_created_at"])
 	zeroRow := output[2]
-	assert.Equal(t, "1970-01-01T00:00:00Z", zeroRow["datetime_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "1970-01-01T00:00:00.000000+00:00", zeroRow["datetime_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "1970-01-01", zeroRow["date_created_at"].(sqltypes.Value).ToString())
-	assert.Equal(t, "1970-01-01T00:00:00Z", zeroRow["timestamp_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "1970-01-01T00:00:00.000000+00:00", zeroRow["timestamp_created_at"].(sqltypes.Value).ToString())
 }


### PR DESCRIPTION
Adds microseconds to outputted timestamps and datetimes, and also starts using time offset format.

**Local example**
Locally, timestamps and datetimes are outputted as:
```
{"type":"RECORD","record":{"stream":"apps","namespace":"test-connectors","emitted_at":1743106205516,"data":{"allow_multiple_experiences_per_access_pass":true,"app_type":"company_app","base_app_id":null,"base_dev_url":"https://dev.example.com","base_preview_url":"https://preview.example.com","base_url":"https://app.example.com","bot_id":null,"capabilities":"{\"feature1\": true, \"feature2\": false}","created_at":"2025-03-27T15:19:37.311976+00:00","data":"{\"config\": \"default\"}","default_experience_description":"A default experience for testing.","description":"This is a sample app for demonstration purposes.","dev_route_id":"dev-123","first_request_at":"2025-03-27T15:19:37.311976+00:00","force_checkout_iframe":false,"hub_cta":"Click here to try it!","id":1,"image_content_type":"image/png","image_file_name":"icon.png","image_file_size":204800,"image_updated_at":"2025-03-27T15:19:37.311976+00:00","image_url":"https://cdn.example.com/icons/icon.png","internal_identifier":"internal_app_001","name":"Sample App","only_private":false,"prod_route_id":"prod-123","product_page":"https://app.example.com/product","proxy_domain_id":"proxy_abc123","recommended":false,"status":"visible","tag":"app_abcdef1234567","total_installs_last_30_days":100,"updated_at":"2025-03-27T15:19:37.311976+00:00","verified":true}}}
{"type":"RECORD","record":{"stream":"apps","namespace":"test-connectors","emitted_at":1743106205516,"data":{"allow_multiple_experiences_per_access_pass":true,"app_type":"company_app","base_app_id":null,"base_dev_url":null,"base_preview_url":null,"base_url":null,"bot_id":null,"capabilities":null,"created_at":"2025-03-27T17:39:57.481161+00:00","data":null,"default_experience_description":null,"description":null,"dev_route_id":null,"first_request_at":null,"force_checkout_iframe":false,"hub_cta":null,"id":2,"image_content_type":null,"image_file_name":null,"image_file_size":null,"image_updated_at":null,"image_url":null,"internal_identifier":null,"name":"Null Value App","only_private":false,"prod_route_id":null,"product_page":null,"proxy_domain_id":"proxy_nulltest_001","recommended":false,"status":"hidden","tag":"app_nulltest_001","total_installs_last_30_days":0,"updated_at":"2025-03-27T17:39:57.481161+00:00","verified":false}}}
```