### PR TITLE
Omit, or add, timezone offset to date, datetime, time, and timestamp

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -154,10 +154,14 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool, nullable st
 		airbyteType = "integer"
 	case strings.HasPrefix(mysqlType, "decimal"), strings.HasPrefix(mysqlType, "double"), strings.HasPrefix(mysqlType, "float"):
 		jsonSchemaType = "number"
-	case strings.HasPrefix(mysqlType, "datetime"), strings.HasPrefix(mysqlType, "timestamp"):
+	case strings.HasPrefix(mysqlType, "datetime"):
 		jsonSchemaType = "string"
 		customFormat = "date-time"
 		airbyteType = "timestamp_without_timezone"
+	case strings.HasPrefix(mysqlType, "timestamp"):
+		jsonSchemaType = "string"
+		customFormat = "date-time"
+		airbyteType = "timestamp_with_timezone"
 	case strings.HasPrefix(mysqlType, "date"):
 		jsonSchemaType = "string"
 		customFormat = "date"
@@ -165,7 +169,7 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool, nullable st
 	case strings.HasPrefix(mysqlType, "time"):
 		jsonSchemaType = "string"
 		customFormat = "time"
-		airbyteType = "time_without_timezone"
+		airbyteType = "time_with_timezone"
 	default:
 		jsonSchemaType = "string"
 	}

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -435,14 +435,24 @@ func TestDiscover_CanPickRightAirbyteType(t *testing.T) {
 			AirbyteType:    "timestamp_without_timezone",
 		},
 		{
+			MysqlType:      "timestamp",
+			JSONSchemaType: []string{"string"},
+			AirbyteType:    "timestamp_with_timezone",
+		},
+		{
+			MysqlType:      "timestamp(6)",
+			JSONSchemaType: []string{"string"},
+			AirbyteType:    "timestamp_with_timezone",
+		},
+		{
 			MysqlType:      "time",
 			JSONSchemaType: []string{"string"},
-			AirbyteType:    "time_without_timezone",
+			AirbyteType:    "time_with_timezone",
 		},
 		{
 			MysqlType:      "time(6)",
 			JSONSchemaType: []string{"string"},
-			AirbyteType:    "time_without_timezone",
+			AirbyteType:    "time_with_timezone",
 		},
 		{
 			MysqlType:      "date",

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -242,6 +242,9 @@ func formatISO8601(mysqlType query.Type, value sqltypes.Value) Value {
 	if mysqlType == query.Type_DATE {
 		formatString = "2006-01-02"
 		layout = time.DateOnly
+	} else if mysqlType == query.Type_DATETIME {
+		formatString = "2006-01-02 15:04:05"
+		layout = "2006-01-02T15:04:05.000000"
 	} else {
 		formatString = "2006-01-02 15:04:05"
 		layout = "2006-01-02T15:04:05.000000-07:00"

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -244,10 +244,10 @@ func formatISO8601(mysqlType query.Type, value sqltypes.Value) Value {
 		layout = time.DateOnly
 	} else if mysqlType == query.Type_DATETIME {
 		formatString = "2006-01-02 15:04:05"
-		layout = "2006-01-02T15:04:05.000000"
+		layout = "2006-01-02T15:04:05.000000" // No timezone offset
 	} else {
 		formatString = "2006-01-02 15:04:05"
-		layout = "2006-01-02T15:04:05.000000-07:00"
+		layout = "2006-01-02T15:04:05.000000-07:00" // Timezone offset
 	}
 
 	var (

--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -184,7 +184,7 @@ func TestCanFormatISO8601Values(t *testing.T) {
 	output := QueryResultToRecords(&input, &PlanetScaleSource{})
 	assert.Equal(t, 3, len(output))
 	row := output[0]
-	assert.Equal(t, "2025-02-14T08:08:08.000000+00:00", row["datetime_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "2025-02-14T08:08:08.000000", row["datetime_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "2025-02-14", row["date_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "2025-02-14T08:08:08.000000+00:00", row["timestamp_created_at"].(sqltypes.Value).ToString())
 	nullRow := output[1]
@@ -192,7 +192,7 @@ func TestCanFormatISO8601Values(t *testing.T) {
 	assert.Equal(t, nil, nullRow["date_created_at"])
 	assert.Equal(t, nil, nullRow["timestamp_created_at"])
 	zeroRow := output[2]
-	assert.Equal(t, "1970-01-01T00:00:00.000000+00:00", zeroRow["datetime_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "1970-01-01T00:00:00.000000", zeroRow["datetime_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "1970-01-01", zeroRow["date_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "1970-01-01T00:00:00.000000+00:00", zeroRow["timestamp_created_at"].(sqltypes.Value).ToString())
 }


### PR DESCRIPTION
This PR makes it so that the following is true:
- `time`
    - becomes `time_with_timezone`
- `timestamp`
    -  becomes `timestamp_with_timezone`
    - We make sure to parse into an ISO 8601 string with microseconds and timezone offset
- `date`
    - becomes `date`
- `datetime`
    - becomes `timestamp_without_timezone`
    - We make sure to parse into an ISO 8601 string with microseconds and **no** timezone offset

This follows Airbyte's documentation: https://docs.airbyte.com/understanding-airbyte/supported-data-types#dates-and-timestamps
  