### PR TITLE
cmd/internal: exit sync at COPY_COMPLETED or stop pos, not after

### DIFF
--- a/cmd/internal/mock_types.go
+++ b/cmd/internal/mock_types.go
@@ -10,25 +10,32 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtgateservice"
 )
 
+type testAirbyteLogEntry struct {
+	level   string
+	message string
+}
+
 type testAirbyteLogger struct {
-	logMessages map[string][]string
-	records     map[string][]map[string]interface{}
+	logMessages        []testAirbyteLogEntry
+	logMessagesByLevel map[string][]string
+	records            map[string][]map[string]interface{}
 }
 
 func (tal *testAirbyteLogger) Log(level, message string) {
-	if tal.logMessages == nil {
-		tal.logMessages = map[string][]string{}
+	if tal.logMessagesByLevel == nil {
+		tal.logMessagesByLevel = map[string][]string{}
 	}
-	tal.logMessages[level] = append(tal.logMessages[level], message)
+	tal.logMessagesByLevel[level] = append(tal.logMessagesByLevel[level], message)
+	tal.logMessages = append(tal.logMessages, testAirbyteLogEntry{level, message})
 }
 
 func (testAirbyteLogger) Catalog(catalog Catalog) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (testAirbyteLogger) ConnectionStatus(status ConnectionStatus) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -44,12 +51,12 @@ func (testAirbyteLogger) Flush() {
 }
 
 func (testAirbyteLogger) State(syncState SyncState) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (testAirbyteLogger) Error(error string) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -121,22 +128,22 @@ func (tma *mysqlAccessMock) PingContext(ctx context.Context, source PlanetScaleS
 }
 
 func (mysqlAccessMock) GetTableNames(ctx context.Context, source PlanetScaleSource) ([]string, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (mysqlAccessMock) GetTableSchema(ctx context.Context, source PlanetScaleSource, s string) (map[string]PropertyType, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (mysqlAccessMock) GetTablePrimaryKeys(ctx context.Context, source PlanetScaleSource, s string) ([]string, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (mysqlAccessMock) QueryContext(ctx context.Context, psc PlanetScaleSource, query string, args ...interface{}) (*sql.Rows, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -146,7 +153,7 @@ func (tma *mysqlAccessMock) GetVitessTablets(ctx context.Context, psc PlanetScal
 }
 
 func (mysqlAccessMock) GetVitessShards(ctx context.Context, psc PlanetScaleSource) ([]string, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 func (mysqlAccessMock) Close() error { return nil }

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -240,8 +240,8 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, w io.Writer, ps Plane
 		return currentSerializedCursor, errors.Wrap(err, "Unable to get latest cursor position")
 	}
 
-	// the last synced VGTID is not at least, or after the current VGTID
-	if currentPosition.Position != "" && !positionEqual(stopPosition, currentPosition.Position) && !positionAfter(stopPosition, currentPosition.Position) {
+	// the last synced VGTID is not after the current VGTID
+	if currentPosition.Position != "" && !positionAfter(stopPosition, currentPosition.Position) {
 		p.Logger.Log(LOGLEVEL_INFO, preamble+"No new GTIDs found, exiting")
 		return TableCursorToSerializedCursor(currentPosition)
 	}

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -424,10 +424,9 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, syncMode string, tc *
 
 		// Exit sync and flush records once the VGTID position is at or past the desired stop position, and we're no longer waiting for COPY phase to complete
 		if canFinishSync {
-			switch {
-			case isFullSync && copyCompletedSeen:
+			if isFullSync {
 				p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sExiting full sync and flushing records because COPY_COMPLETED event was seen, current position is %+v, stop position is %+v", preamble, tc.Position, stopPosition))
-			case !isFullSync && (positionEqual(tc.Position, stopPosition) || positionAfter(tc.Position, stopPosition)):
+			} else {
 				p.Logger.Log(LOGLEVEL_INFO, fmt.Sprintf("%sExiting incremental sync and flushing records because current position %+v has reached or passed stop position %+v", preamble, tc.Position, stopPosition))
 			}
 			return tc, resultCount, io.EOF

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -633,7 +633,7 @@ func TestRead_CanPickReplicaForUnshardedKeyspaces(t *testing.T) {
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
 	assert.Equal(t, esc, sc)
-	assert.Equal(t, 2, vsc.vstreamFnInvokedCount)
+	assert.Equal(t, 1, vsc.vstreamFnInvokedCount)
 	assert.False(t, tma.PingContextFnInvoked)
 	assert.False(t, tma.GetVitessTabletsFnInvoked)
 }
@@ -703,7 +703,7 @@ func TestRead_IncrementalSync_CanReturnOriginalCursorIfNoNewFound(t *testing.T) 
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
 	assert.Equal(t, esc, sc)
-	assert.Equal(t, 2, vsc.vstreamFnInvokedCount)
+	assert.Equal(t, 1, vsc.vstreamFnInvokedCount)
 }
 
 // CanReturnNewCursorIfNewFound tests returning the GTid after the stop position as the start GTid for the next sync

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -1015,9 +1015,9 @@ func TestRead_IncrementalSync_CanStopAtWellKnownCursor(t *testing.T) {
 	assert.Equal(t, 10, len(responses))
 	logLines := tal.logMessagesByLevel[LOGLEVEL_INFO]
 	// But only the first 8 (with VGtids <= stop position) will be synced
-	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] Finished reading %v records after 1 syncs for table [customers]", 8), logLines[len(logLines)-1])
+	assert.Equal(t, fmt.Sprintf("[connect-test:primary:customers shard : -] Finished reading %v records after 1 syncs for table [customers]", 9), logLines[len(logLines)-1])
 	records := tal.records["connect-test.customers"]
-	assert.Equal(t, 8, len(records))
+	assert.Equal(t, 9, len(records))
 }
 
 // CanLogResults tests synced records from stopping & flushing records once stop position is passed


### PR DESCRIPTION
## Problem

During the Airbyte sync, the replication job _should_ exit:

* During an initial sync, once the `COPY_COMPLETED` event is seen.
* During a followup increment sync, once the stop position is reached.

However, this is not happening. Instead, an _additional_ VStream event must be seen by the airbyte-source before the replication job exits. This isn't ideal. 

The bigger problem, however, is that if the additional VStream event was produced by an `INSERT`, that row is not captured by the initial sync _nor_ by subsequent syncs.

## Changes

* On a full sync, exit immediately after `COPY_COMPLETED` event is seen.
* On an increment immediately after the current position is after _or equal_ to the stop position.

Make sure to flush any pending rows _before_ exiting the sync.

## Repro

Setup:
* A PlanetScale database.
* Local Postgres v14.
* Airbyte locally.
* PlanetScale airbyte-source v2.7.0.
* Postgres destination.
* Connection with "incremental sync | append + dedupe".

Do an initial sync:

1. Create a table with 10 rows.
2. Start Airbyte sync.
3. The `COPY_COMPLETED` event is seen, but the replication job does not finish.
4. Insert an 11th row.
5. The replication job completes, and 10 rows were captured.

Do a subsequent sync:

1. Start Airbyte sync.
2. The replication job completes, no additional rows are captured.

Insert a row, and start another sync:

1. Insert a 12th row.
2. Start Airbyte sync.
3. The sync finds the stop position but the replication job does not finish.
4. Insert a 13th row.
5. The replication job completes, the 12th row is captured, but not the 11th or 13th. 

Do a subsequent sync:

1. Start Airbyte sync.
2. The replication job completes, no additional rows are captured.

Insert a row, and start another sync:

1. Insert a 14th row.
2. Start Airbyte sync.
3. The sync finds the stop position but the replication job does not finish.
4. Insert a 15th row.
5. The replication job completes, the 14th row is captured, but not the 11th, 13th or 15th.

3 rows are missing, and as far as I can tell will never by captured.