### PR TITLE
Revert "Add timezone info to datetime"

### DIFF
--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -244,7 +244,7 @@ func formatISO8601(mysqlType query.Type, value sqltypes.Value) Value {
 		layout = time.DateOnly
 	} else if mysqlType == query.Type_DATETIME {
 		formatString = "2006-01-02 15:04:05"
-		layout = "2006-01-02T15:04:05.000000-07:00" // Airbyte requires timezone offset for datetime as well
+		layout = "2006-01-02T15:04:05.000000" // No timezone offset
 	} else {
 		formatString = "2006-01-02 15:04:05"
 		layout = "2006-01-02T15:04:05.000000-07:00" // Timezone offset

--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -184,7 +184,7 @@ func TestCanFormatISO8601Values(t *testing.T) {
 	output := QueryResultToRecords(&input, &PlanetScaleSource{})
 	assert.Equal(t, 3, len(output))
 	row := output[0]
-	assert.Equal(t, "2025-02-14T08:08:08.000000+00:00", row["datetime_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "2025-02-14T08:08:08.000000", row["datetime_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "2025-02-14", row["date_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "2025-02-14T08:08:08.000000+00:00", row["timestamp_created_at"].(sqltypes.Value).ToString())
 	nullRow := output[1]
@@ -192,7 +192,7 @@ func TestCanFormatISO8601Values(t *testing.T) {
 	assert.Equal(t, nil, nullRow["date_created_at"])
 	assert.Equal(t, nil, nullRow["timestamp_created_at"])
 	zeroRow := output[2]
-	assert.Equal(t, "1970-01-01T00:00:00.000000+00:00", zeroRow["datetime_created_at"].(sqltypes.Value).ToString())
+	assert.Equal(t, "1970-01-01T00:00:00.000000", zeroRow["datetime_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "1970-01-01", zeroRow["date_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "1970-01-01T00:00:00.000000+00:00", zeroRow["timestamp_created_at"].(sqltypes.Value).ToString())
 }


### PR DESCRIPTION
Reverts planetscale/airbyte-source#130

Users actually found that, despite the lack of Airbyte schema validation errors after this change, they actually had worse datetime values in the end destination (BigQuery). Revert for now until we figure out why this happens - prioritize data making it to the destination over schema validation logs.