### PR TITLE
cmd/internal: make sure decimal type values lead with zero prior to json encoding

### DIFF
--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -224,8 +224,14 @@ func leadDecimalWithZero(val sqltypes.Value) sqltypes.Value {
 		panic("non-decimal value")
 	}
 	valS := val.ToString()
-	if strings.HasPrefix(valS, ".") {
-		newVal, err := sqltypes.NewValue(val.Type(), fmt.Appendf(nil, "0%s", valS))
+	if strings.HasPrefix(valS, ".") || strings.HasPrefix(valS, "-.") {
+		var newVal sqltypes.Value
+		var err error
+		if strings.HasPrefix(valS, ".") {
+			newVal, err = sqltypes.NewValue(val.Type(), fmt.Appendf(nil, "0%s", valS))
+		} else {
+			newVal, err = sqltypes.NewValue(val.Type(), fmt.Appendf(nil, "-0%s", valS[1:]))
+		}
 		if err != nil {
 			panic(fmt.Sprintf("failed to reconstruct decimal with leading zero: %v", err))
 		}

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -225,7 +225,7 @@ func leadDecimalWithZero(val sqltypes.Value) sqltypes.Value {
 	}
 	valS := val.ToString()
 	if strings.HasPrefix(valS, ".") {
-		newVal, err := sqltypes.NewValue(val.Type(), []byte(fmt.Sprintf("0%s", valS)))
+		newVal, err := sqltypes.NewValue(val.Type(), fmt.Appendf(nil, "0%s", valS))
 		if err != nil {
 			panic(fmt.Sprintf("failed to reconstruct decimal with leading zero: %v", err))
 		}

--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -210,9 +210,9 @@ func TestCanLeadDecimalWithZero(t *testing.T) {
 	input := sqltypes.Result{
 		Fields: []*query.Field{
 			{Name: "d1", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
-			{Name: "d2", Type: sqltypes.Date, ColumnType: "decimal(10,2)"},
-			{Name: "d3", Type: sqltypes.Time, ColumnType: "decimal(10,2)"},
-			{Name: "d4", Type: sqltypes.Time, ColumnType: "decimal(10,2)"},
+			{Name: "d2", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
+			{Name: "d3", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
+			{Name: "d4", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
 		},
 		Rows: [][]sqltypes.Value{
 			{d1, d2, d3, d4},
@@ -225,6 +225,6 @@ func TestCanLeadDecimalWithZero(t *testing.T) {
 	row := output[0]
 	assert.Equal(t, "11.11", row["d1"].(sqltypes.Value).ToString())
 	assert.Equal(t, "2.22", row["d2"].(sqltypes.Value).ToString())
-	assert.Equal(t, ".33", row["d3"].(sqltypes.Value).ToString())
-	assert.Equal(t, ".04", row["d4"].(sqltypes.Value).ToString())
+	assert.Equal(t, "0.33", row["d3"].(sqltypes.Value).ToString())
+	assert.Equal(t, "0.04", row["d4"].(sqltypes.Value).ToString())
 }

--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -196,3 +196,35 @@ func TestCanFormatISO8601Values(t *testing.T) {
 	assert.Equal(t, "1970-01-01", zeroRow["date_created_at"].(sqltypes.Value).ToString())
 	assert.Equal(t, "1970-01-01T00:00:00.000000+00:00", zeroRow["timestamp_created_at"].(sqltypes.Value).ToString())
 }
+
+func TestCanLeadDecimalWithZero(t *testing.T) {
+	d1, err := sqltypes.NewValue(query.Type_DECIMAL, []byte("11.11"))
+	assert.NoError(t, err)
+	d2, err := sqltypes.NewValue(query.Type_DECIMAL, []byte("2.22"))
+	assert.NoError(t, err)
+	d3, err := sqltypes.NewValue(query.Type_DECIMAL, []byte(".33"))
+	assert.NoError(t, err)
+	d4, err := sqltypes.NewValue(query.Type_DECIMAL, []byte(".04"))
+	assert.NoError(t, err)
+
+	input := sqltypes.Result{
+		Fields: []*query.Field{
+			{Name: "d1", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
+			{Name: "d2", Type: sqltypes.Date, ColumnType: "decimal(10,2)"},
+			{Name: "d3", Type: sqltypes.Time, ColumnType: "decimal(10,2)"},
+			{Name: "d4", Type: sqltypes.Time, ColumnType: "decimal(10,2)"},
+		},
+		Rows: [][]sqltypes.Value{
+			{d1, d2, d3, d4},
+		},
+	}
+
+	output := QueryResultToRecords(&input, &PlanetScaleSource{})
+	assert.Equal(t, 1, len(output))
+
+	row := output[0]
+	assert.Equal(t, "11.11", row["d1"].(sqltypes.Value).ToString())
+	assert.Equal(t, "2.22", row["d2"].(sqltypes.Value).ToString())
+	assert.Equal(t, ".33", row["d3"].(sqltypes.Value).ToString())
+	assert.Equal(t, ".04", row["d4"].(sqltypes.Value).ToString())
+}

--- a/cmd/internal/types_test.go
+++ b/cmd/internal/types_test.go
@@ -204,7 +204,13 @@ func TestCanLeadDecimalWithZero(t *testing.T) {
 	assert.NoError(t, err)
 	d3, err := sqltypes.NewValue(query.Type_DECIMAL, []byte(".33"))
 	assert.NoError(t, err)
-	d4, err := sqltypes.NewValue(query.Type_DECIMAL, []byte(".04"))
+	d4, err := sqltypes.NewValue(query.Type_DECIMAL, []byte("0.4"))
+	assert.NoError(t, err)
+	d5, err := sqltypes.NewValue(query.Type_DECIMAL, []byte("-5.55"))
+	assert.NoError(t, err)
+	d6, err := sqltypes.NewValue(query.Type_DECIMAL, []byte("-0.66"))
+	assert.NoError(t, err)
+	d7, err := sqltypes.NewValue(query.Type_DECIMAL, []byte("-.77"))
 	assert.NoError(t, err)
 
 	input := sqltypes.Result{
@@ -213,9 +219,12 @@ func TestCanLeadDecimalWithZero(t *testing.T) {
 			{Name: "d2", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
 			{Name: "d3", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
 			{Name: "d4", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
+			{Name: "d5", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
+			{Name: "d6", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
+			{Name: "d7", Type: sqltypes.Decimal, ColumnType: "decimal(10,2)"},
 		},
 		Rows: [][]sqltypes.Value{
-			{d1, d2, d3, d4},
+			{d1, d2, d3, d4, d5, d6, d7},
 		},
 	}
 
@@ -226,5 +235,8 @@ func TestCanLeadDecimalWithZero(t *testing.T) {
 	assert.Equal(t, "11.11", row["d1"].(sqltypes.Value).ToString())
 	assert.Equal(t, "2.22", row["d2"].(sqltypes.Value).ToString())
 	assert.Equal(t, "0.33", row["d3"].(sqltypes.Value).ToString())
-	assert.Equal(t, "0.04", row["d4"].(sqltypes.Value).ToString())
+	assert.Equal(t, "0.4", row["d4"].(sqltypes.Value).ToString())
+	assert.Equal(t, "-5.55", row["d5"].(sqltypes.Value).ToString())
+	assert.Equal(t, "-0.66", row["d6"].(sqltypes.Value).ToString())
+	assert.Equal(t, "-0.77", row["d7"].(sqltypes.Value).ToString())
 }


### PR DESCRIPTION
At some point, and for some reason, decimal type values <1 are expressed by `(sqltypes.Value).ToString()` without leading zeros. This becomes a problem when those values go through JSON encoding on their way to Airbyte destinations.

As a hack, make sure we lead these values with zeros.