### PR TITLE
add option to use gtid position together with last known pk

### DIFF
--- a/cmd/airbyte-source/spec.json
+++ b/cmd/airbyte-source/spec.json
@@ -81,6 +81,13 @@
           "description": "Timeout in seconds for a sync attempt",
           "order": 9
         },
+        "use_gtid_with_table_pks": {
+          "type": "boolean",
+          "title": "Use GTID with table primary keys",
+          "default": false,
+          "description": "Use GTID position together with table primary keys",
+          "order": 10
+        },
         "options": {
           "type": "object",
           "title": "Customize serialization",

--- a/cmd/internal/planetscale_connection.go
+++ b/cmd/internal/planetscale_connection.go
@@ -12,17 +12,18 @@ import (
 
 // PlanetScaleSource defines a configured Airbyte Source for a PlanetScale database
 type PlanetScaleSource struct {
-	Host           string              `json:"host"`
-	Database       string              `json:"database"`
-	Username       string              `json:"username"`
-	Password       string              `json:"password"`
-	Shards         string              `json:"shards"`
-	UseReplica     bool                `json:"use_replica"`
-	UseRdonly      bool                `json:"use_rdonly"`
-	StartingGtids  string              `json:"starting_gtids"`
-	Options        CustomSourceOptions `json:"options"`
-	MaxRetries     uint                `json:"max_retries"`
-	TimeoutSeconds *int                `json:"timeout_seconds"`
+	Host                string              `json:"host"`
+	Database            string              `json:"database"`
+	Username            string              `json:"username"`
+	Password            string              `json:"password"`
+	Shards              string              `json:"shards"`
+	UseReplica          bool                `json:"use_replica"`
+	UseRdonly           bool                `json:"use_rdonly"`
+	StartingGtids       string              `json:"starting_gtids"`
+	Options             CustomSourceOptions `json:"options"`
+	MaxRetries          uint                `json:"max_retries"`
+	TimeoutSeconds      *int                `json:"timeout_seconds"`
+	UseGTIDWithTablePKs bool                `json:"use_gtid_with_table_pks"`
 }
 
 type CustomSourceOptions struct {

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -303,7 +303,7 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, syncMode string, tc *
 		defer conn.Close()
 	}
 
-	if tc.LastKnownPk != nil {
+	if tc.LastKnownPk != nil && !ps.UseGTIDWithTablePKs {
 		tc.Position = ""
 	}
 


### PR DESCRIPTION
Currently when airbyte-source syncs it wipes out `gtid` information from the shard gtid before passing it along in the VStream request. This means that, upon retry, it's possible for the connector to lose rows that are inserted between the `gtid` of the last `vgtid` event it received in one attempt and the `@@gtid_executed` of the next sync attempt.

This new option changes the current behavior so that `gtid` is always passed along in the VStream request, if it is available. This makes for a safer retry. However, it does mean that it is possible for the connector to received duplicates of the same row. 

How it will look in Airbyte UI after upgrading to a version with this change.

<img width="849" alt="image" src="https://github.com/user-attachments/assets/5d699e82-3e37-4459-a833-365f717cea15" />
