### PR TITLE
Modified regex and tests for new Vitess table names

### DIFF
--- a/cmd/internal/planetscale_edge_mysql.go
+++ b/cmd/internal/planetscale_edge_mysql.go
@@ -112,7 +112,7 @@ func (p planetScaleEdgeMySQLAccess) PingContext(ctx context.Context, psc PlanetS
 }
 
 const (
-	gCTableNameExpression    string = `^_vt_(HOLD|PURGE|EVAC|DROP)_([0-f]{32})_([0-9]{14})$`
+	gCTableNameExpression    string = `_[0-9a-zA-Z]{8}_[0-9a-zA-Z]{4}_[0-9a-zA-Z]{4}_.*|_vt_.*`
 	vreplTableNameExpression string = `\b_(\w+|\d+)_\d+_vrepl\b`
 )
 

--- a/cmd/internal/planetscale_edge_mysql_test.go
+++ b/cmd/internal/planetscale_edge_mysql_test.go
@@ -13,6 +13,46 @@ func TestFilterNames_CanFilterInternalVitessTables(t *testing.T) {
 		filtered  bool
 	}{
 		{
+			name:      "filters_vt_hld_tables",
+			tableName: "_vt_hld_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_",
+			filtered:  true,
+		},
+		{
+			name:      "filters_vt_prg_tables",
+			tableName: "_vt_prg_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_",
+			filtered:  true,
+		},
+		{
+			name:      "filters_vt_evc_tables",
+			tableName: "_vt_evc_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_",
+			filtered:  true,
+		},
+		{
+			name:      "filters_vt_drp_tables",
+			tableName: "_vt_drp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_",
+			filtered:  true,
+		},
+		{
+			name:      "filters_vt_vrp_tables",
+			tableName: "_vt_vrp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_",
+			filtered:  true,
+		},
+		{
+			name:      "filters_vt_gho_tables",
+			tableName: "_vt_gho_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_",
+			filtered:  true,
+		},
+		{
+			name:      "filters_vt_ghc_tables",
+			tableName: "_vt_ghc_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_",
+			filtered:  true,
+		},
+		{
+			name:      "filters_vt_del_tables",
+			tableName: "_vt_del_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_",
+			filtered:  true,
+		},
+		{
 			name:      "filters_vrepl_tables",
 			tableName: "_750a3e1f_e6f3_5249_82af_82f5d325ecab_20240528153135_vrepl",
 			filtered:  true,


### PR DESCRIPTION
Used the same regex from:
https://github.com/planetscale/api-bb/pull/14322

I was able to re-run the test function after adjusting the regex and adding the extra test cases and it was successful so should hopefully this should address what was described in https://github.com/planetscale/surfaces/issues/3084.