### PR TITLE
ci: pin CodeQL workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,22 +22,22 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '>=1.18.0'
         check-latest: true
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

The "Analyze (go)" (CodeQL) check fails on every PR with:

> The actions `actions/checkout@v3`, `actions/setup-go@v3`, and `github/codeql-action/init@v2` are not allowed in `planetscale/airbyte-source` because all actions must be pinned to a full-length commit SHA.

The org now enforces commit-SHA pinning for GitHub Actions, and `.github/workflows/codeql.yml` still referenced actions by version tag.

## Changes

Pin every action in the CodeQL workflow to its release commit SHA (with a `# vX` comment for readability). Bumped off the deprecated majors while here:

- `actions/checkout` `v3` → `v4` (`34e1148`)
- `actions/setup-go` `v3` → `v5` (`40f1582`)
- `github/codeql-action/{init,autobuild,analyze}` `v2` → `v3` (`dd903d2`)

This unblocks CI on all open PRs (including #153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
