### PR TITLE
Remove connect-enabled hostname check to support PrivateLink hosts

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -55,9 +55,6 @@ func (p PlanetScaleEdgeDatabase) CanConnect(ctx context.Context, psc PlanetScale
 }
 
 func (p PlanetScaleEdgeDatabase) checkEdgePassword(ctx context.Context, psc PlanetScaleSource) error {
-	if !strings.HasSuffix(psc.Host, ".connect.psdb.cloud") {
-		return errors.New("This password is not connect-enabled, please ensure that your organization is enrolled in the Connect beta.")
-	}
 	reqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fmt.Sprintf("https://%v", psc.Host), nil)


### PR DESCRIPTION
CanConnect previously rejected any host that did not end in ".connect.psdb.cloud" with the error "This password is not connect-enabled, please ensure that your organization is enrolled in the Connect beta." That suffix check was added early on, when Connect was a beta capability that not all PlanetScale credentials had enabled, so it served as an early guard to steer users toward opting in.

Connect is now enabled for all PlanetScale credentials, so the check no longer guards anything real. It does, however, block legitimate setups: customers connecting over an AWS PrivateLink endpoint use a hostname that does not end in ".connect.psdb.cloud", so the connector refuses to connect even though the credentials are valid.

This removes only the hostname suffix check. The HTTPS reachability probe in checkEdgePassword is retained, so we still fail fast with a clear error when the host is genuinely unreachable. This also brings the Airbyte source in line with the Fivetran source, whose checkEdgePassword performs the reachability probe without any hostname suffix check.

No tests cover this path, and the `strings` import is still used elsewhere in the file.